### PR TITLE
Add CI workflow for Node checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run end-to-end tests
+        run: npm run e2e:ci


### PR DESCRIPTION
## Summary
- add a CI workflow that runs on pushes and pull requests
- set up Node.js with npm cache and run lint, test, and e2e commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2b27cc248328a7bb5d050fc3da6a