### PR TITLE
Add custom 404 page

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page Not Found · Tic Tac Toe</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Oops! Page Not Found</h1>
+      <p>
+        The page you were looking for isn’t here. It might have been moved,
+        removed, or maybe the URL was mistyped.
+      </p>
+      <a class="button" href="../index.html">Return to the game</a>
+    </main>
+  </body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,73 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #f0f4ff, #ffffff);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1f2933;
+}
+
+main {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  padding: 48px 56px;
+  max-width: 480px;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.75rem;
+  margin-bottom: 16px;
+}
+
+p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+a.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 24px;
+  border-radius: 9999px;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+a.button:hover {
+  background: #1d4ed8;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(29, 78, 216, 0.4);
+}
+
+a.button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 4px;
+}
+
+@media (max-width: 480px) {
+  main {
+    padding: 32px 24px;
+  }
+
+  h1 {
+    font-size: 2.1rem;
+  }
+
+  p {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a custom 404 page for the static site with a friendly message and navigation back home
- include the shared site stylesheet so the error page matches the rest of the site

## Testing
- manual verification of http://127.0.0.1:8000/site/404.html while running `python -m http.server`


------
https://chatgpt.com/codex/tasks/task_e_68df2b2e86a4832886dd5a7c19f9c016