### PR TITLE
Refactor board layout to grid buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,59 +1,24 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tic Tac Toe</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
-    }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
-    }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
-      cursor: pointer;
-    }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
-    }
-    
-    .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
-    }
-  </style>
+  <link rel="stylesheet" href="site/css/style.css">
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <div class="board" role="grid" aria-label="Tic Tac Toe board">
+    <button class="board__cell" role="gridcell" data-cell data-row="0" data-col="0" aria-label="Row 1, Column 1"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="0" data-col="1" aria-label="Row 1, Column 2"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="0" data-col="2" aria-label="Row 1, Column 3"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="1" data-col="0" aria-label="Row 2, Column 1"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="1" data-col="1" aria-label="Row 2, Column 2"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="1" data-col="2" aria-label="Row 2, Column 3"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="2" data-col="0" aria-label="Row 3, Column 1"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="2" data-col="1" aria-label="Row 3, Column 2"></button>
+    <button class="board__cell" role="gridcell" data-cell data-row="2" data-col="2" aria-label="Row 3, Column 3"></button>
+  </div>
+  <div class="message" aria-live="polite"></div>
 
   <script>
     var currentPlayer = 'X';
@@ -63,26 +28,49 @@
       ['', '', '']
     ];
     var gameOver = false;
-    
-    function makeMove(row, col) {
+
+    var boardElement = document.querySelector('.board');
+    var messageElement = document.querySelector('.message');
+    var cells = Array.from(boardElement.querySelectorAll('[data-cell]'));
+
+    cells.forEach(function (cell) {
+      cell.addEventListener('click', handleCellClick);
+    });
+
+    function handleCellClick(event) {
+      var cell = event.currentTarget;
+      var row = Number(cell.dataset.row);
+      var col = Number(cell.dataset.col);
+
       if (gameOver || board[row][col] !== '') {
         return;
       }
-      
+
       board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
+      cell.textContent = currentPlayer;
+      cell.classList.add(currentPlayer === 'X' ? 'cell--x' : 'cell--o');
+      cell.disabled = true;
+      cell.setAttribute('aria-label', 'Row ' + (row + 1) + ', Column ' + (col + 1) + ', ' + currentPlayer);
+
       if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
+        messageElement.textContent = currentPlayer + ' wins!';
         gameOver = true;
+        finalizeBoard();
       } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
+        messageElement.textContent = "It's a draw!";
         gameOver = true;
+        finalizeBoard();
       } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
       }
     }
-    
+
+    function finalizeBoard() {
+      cells.forEach(function (cell) {
+        cell.disabled = true;
+      });
+    }
+
     function checkWin(player) {
       for (var i = 0; i < 3; i++) {
         if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
@@ -92,17 +80,17 @@
           return true; // Vertical
         }
       }
-      
+
       if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
         return true; // Diagonal
       }
       if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
         return true; // Diagonal
       }
-      
+
       return false;
     }
-    
+
     function checkDraw() {
       for (var i = 0; i < 3; i++) {
         for (var j = 0; j < 3; j++) {
@@ -111,7 +99,7 @@
           }
         }
       }
-      
+
       return true;
     }
   </script>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,95 @@
+:root {
+  --color-background: #ffffff;
+  --color-border: #cccccc;
+  --color-text: #222222;
+  --color-x: #d6336c;
+  --color-o: #1c7ed6;
+  --color-hover: #f2f2f2;
+  --color-hover-x: #f8d2df;
+  --color-hover-o: #d7e9fb;
+  --gap-size: clamp(0.5rem, 2vw, 1rem);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  padding: 2rem 1rem;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--gap-size);
+  width: min(90vmin, 24rem);
+}
+
+.board__cell {
+  aspect-ratio: 1;
+  border: 2px solid var(--color-border);
+  border-radius: 0.75rem;
+  font-size: clamp(2.5rem, 12vmin, 4.5rem);
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.board__cell:hover,
+.board__cell:focus-visible {
+  background-color: var(--color-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  outline: none;
+}
+
+.board__cell.cell--x {
+  color: var(--color-x);
+}
+
+.board__cell.cell--o {
+  color: var(--color-o);
+}
+
+.board__cell.cell--x:hover,
+.board__cell.cell--x:focus-visible {
+  background-color: var(--color-hover-x);
+}
+
+.board__cell.cell--o:hover,
+.board__cell.cell--o:focus-visible {
+  background-color: var(--color-hover-o);
+}
+
+.board__cell:disabled {
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.board__cell:disabled:hover,
+.board__cell:disabled:focus-visible {
+  background-color: var(--color-background);
+  box-shadow: none;
+}
+
+.message {
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- replace the table markup with an accessible grid of buttons wired into the existing game logic
- add a dedicated stylesheet that uses CSS Grid to keep the board responsive and square while styling X/O interactions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df2b32499883289c7287c9bad84153