### PR TITLE
Refactor tic-tac-toe layout into semantic sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,119 +1,35 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tic Tac Toe</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
-    }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
-    }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
-      cursor: pointer;
-    }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
-    }
-    
-    .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
-    }
-  </style>
+  <link rel="stylesheet" href="site/css/style.css">
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <header class="site-header">
+    <h1 class="site-title">Tic Tac Toe</h1>
+    <button class="theme-toggle" type="button" data-theme-toggle>Toggle Theme</button>
+  </header>
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
-          }
-        }
-      }
-      
-      return true;
-    }
-  </script>
+  <main class="site-main">
+    <section class="board-wrapper" aria-label="Game board">
+      <div class="board" data-board></div>
+    </section>
+
+    <section class="status-wrapper" aria-live="polite">
+      <p class="status-message" data-status>Player X's turn</p>
+    </section>
+
+    <section class="controls-wrapper">
+      <button class="control-button" type="button" data-reset>Reset Game</button>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>Built for fun and practice.</p>
+  </footer>
+
+  <script type="module" src="site/js/main.js"></script>
 </body>
 </html>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,138 @@
+:root {
+  color-scheme: light dark;
+  --background-color: #f9f9f9;
+  --foreground-color: #111;
+  --accent-color: #0070f3;
+  --border-color: #ccc;
+  --board-size: clamp(240px, 60vw, 360px);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: var(--background-color);
+  color: var(--foreground-color);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.site-header,
+.site-footer {
+  padding: 1.5rem;
+  text-align: center;
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.site-title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+}
+
+.theme-toggle {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  border-color: var(--accent-color);
+  outline: none;
+}
+
+.site-main {
+  display: grid;
+  place-items: center;
+  gap: 2rem;
+  padding: 2rem 1rem;
+}
+
+.board-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  width: var(--board-size);
+  height: var(--board-size);
+}
+
+.board button {
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  border: 2px solid var(--border-color);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.02);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.board button:hover,
+.board button:focus-visible {
+  background: rgba(0, 0, 0, 0.08);
+  outline: none;
+}
+
+.board button:active {
+  transform: scale(0.97);
+}
+
+.status-wrapper {
+  text-align: center;
+}
+
+.status-message {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.controls-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.control-button {
+  padding: 0.6rem 1.4rem;
+  border: none;
+  border-radius: 999px;
+  background-color: var(--accent-color);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.control-button:hover,
+.control-button:focus-visible {
+  background-color: #0056b3;
+  outline: none;
+}
+
+.control-button:active {
+  transform: scale(0.97);
+}
+
+body.dark-theme {
+  --background-color: #050505;
+  --foreground-color: #f9f9f9;
+  --accent-color: #5b8aff;
+  --border-color: rgba(255, 255, 255, 0.2);
+}
+
+.site-footer {
+  font-size: 0.875rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+body.dark-theme .site-footer {
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,0 +1,102 @@
+const boardElement = document.querySelector('[data-board]');
+const statusElement = document.querySelector('[data-status]');
+const resetButton = document.querySelector('[data-reset]');
+const themeToggle = document.querySelector('[data-theme-toggle]');
+
+const BOARD_SIZE = 3;
+let boardState = [];
+let currentPlayer = 'X';
+let isGameOver = false;
+
+function createSquare(row, column) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.setAttribute('data-row', row);
+  button.setAttribute('data-column', column);
+  button.addEventListener('click', () => handleMove(row, column, button));
+  return button;
+}
+
+function initializeBoard() {
+  boardElement.innerHTML = '';
+  boardState = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(''));
+
+  for (let row = 0; row < BOARD_SIZE; row += 1) {
+    for (let column = 0; column < BOARD_SIZE; column += 1) {
+      boardElement.appendChild(createSquare(row, column));
+    }
+  }
+
+  currentPlayer = 'X';
+  isGameOver = false;
+  updateStatus(`${describePlayer(currentPlayer)}'s turn`);
+}
+
+function describePlayer(player) {
+  return `Player ${player}`;
+}
+
+function handleMove(row, column, button) {
+  if (isGameOver || boardState[row][column]) {
+    return;
+  }
+
+  boardState[row][column] = currentPlayer;
+  button.textContent = currentPlayer;
+
+  if (checkWin(currentPlayer)) {
+    updateStatus(`${describePlayer(currentPlayer)} wins!`);
+    isGameOver = true;
+    return;
+  }
+
+  if (isDraw()) {
+    updateStatus("It's a draw!");
+    isGameOver = true;
+    return;
+  }
+
+  currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+  updateStatus(`${describePlayer(currentPlayer)}'s turn`);
+}
+
+function updateStatus(message) {
+  statusElement.textContent = message;
+}
+
+function buildCoordinateLines() {
+  const rows = Array.from({ length: BOARD_SIZE }, (_, rowIndex) =>
+    Array.from({ length: BOARD_SIZE }, (_, columnIndex) => [rowIndex, columnIndex])
+  );
+
+  const columns = Array.from({ length: BOARD_SIZE }, (_, columnIndex) =>
+    Array.from({ length: BOARD_SIZE }, (_, rowIndex) => [rowIndex, columnIndex])
+  );
+
+  const diagonals = [
+    Array.from({ length: BOARD_SIZE }, (_, index) => [index, index]),
+    Array.from({ length: BOARD_SIZE }, (_, index) => [index, BOARD_SIZE - 1 - index])
+  ];
+
+  return [...rows, ...columns, ...diagonals];
+}
+
+const coordinateLines = buildCoordinateLines();
+
+function checkWin(player) {
+  return coordinateLines.some((line) =>
+    line.every(([row, column]) => boardState[row][column] === player)
+  );
+}
+
+function isDraw() {
+  return boardState.flat().every(Boolean);
+}
+
+resetButton.addEventListener('click', initializeBoard);
+
+themeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('dark-theme');
+});
+
+initializeBoard();


### PR DESCRIPTION
## Summary
- replace the inline table layout with semantic header, main, and footer sections
- move styles into site/css/style.css and scripts into the ES module site/js/main.js
- preserve tic-tac-toe gameplay while adding theme toggle and reset controls placeholders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2b32f1d08328b78601ebe0da4534