### PR TITLE
Add UI reset controls for tic tac toe

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tic Tac Toe</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #0f172a;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(160deg, #1e293b, #0f172a 60%);
+      color: #e2e8f0;
+    }
+
+    .app {
+      width: min(90vw, 420px);
+      padding: 2.5rem 2rem;
+      border-radius: 24px;
+      background: rgba(15, 23, 42, 0.9);
+      box-shadow: 0 40px 60px rgba(15, 15, 36, 0.45);
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.75rem;
+      font-weight: 700;
+      text-align: center;
+      letter-spacing: 0.04em;
+    }
+
+    .status {
+      margin: 0;
+      text-align: center;
+      font-size: 1.2rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      min-height: 1.5em;
+    }
+
+    .board {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.75rem;
+    }
+
+    .cell {
+      width: 100%;
+      aspect-ratio: 1;
+      border-radius: 18px;
+      border: none;
+      background: linear-gradient(160deg, rgba(248, 250, 252, 0.05), rgba(15, 23, 42, 0.75));
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+      color: #f8fafc;
+      font-size: 2.75rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+    }
+
+    .cell:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.5), 0 10px 18px rgba(15, 23, 42, 0.45);
+      background: linear-gradient(160deg, rgba(94, 234, 212, 0.25), rgba(56, 189, 248, 0.15));
+    }
+
+    .cell:focus-visible {
+      outline: 3px solid rgba(94, 234, 212, 0.75);
+      outline-offset: 4px;
+    }
+
+    .cell:disabled {
+      cursor: default;
+      opacity: 0.5;
+      transform: none;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      border-radius: 18px;
+      background: rgba(15, 23, 42, 0.6);
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+    }
+
+    .controls__group {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex: 1 1 auto;
+      min-width: 180px;
+    }
+
+    .controls__label {
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+
+    .controls__select {
+      flex: 1;
+      padding: 0.45rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      background: rgba(15, 23, 42, 0.85);
+      color: inherit;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+
+    .controls__button {
+      padding: 0.55rem 1.5rem;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(120deg, rgba(14, 165, 233, 0.85), rgba(129, 140, 248, 0.95));
+      color: #0f172a;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 25px rgba(14, 165, 233, 0.35);
+      flex-shrink: 0;
+    }
+
+    .controls__button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 28px rgba(129, 140, 248, 0.45);
+    }
+
+    .controls__button:focus-visible {
+      outline: 3px solid rgba(129, 140, 248, 0.8);
+      outline-offset: 4px;
+    }
+
+    @media (max-width: 480px) {
+      .app {
+        padding: 2rem 1.5rem;
+        gap: 1.25rem;
+      }
+
+      .controls {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .controls__group {
+        width: 100%;
+      }
+
+      .controls__button {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app" aria-labelledby="title">
+    <h1 id="title">Tic Tac Toe</h1>
+    <p class="status" data-status aria-live="polite">Player X's turn</p>
+    <div class="controls" aria-label="Game controls">
+      <div class="controls__group">
+        <label class="controls__label" for="starting-player">Starting player</label>
+        <select id="starting-player" class="controls__select" data-starting-player>
+          <option value="X" selected>Player X</option>
+          <option value="O">Player O</option>
+        </select>
+      </div>
+      <button type="button" class="controls__button" data-action="new-game">New Game</button>
+    </div>
+    <div class="board" data-board role="grid" aria-label="Tic Tac Toe board">
+      <button type="button" class="cell" data-cell="0" role="gridcell" aria-label="Cell 1"></button>
+      <button type="button" class="cell" data-cell="1" role="gridcell" aria-label="Cell 2"></button>
+      <button type="button" class="cell" data-cell="2" role="gridcell" aria-label="Cell 3"></button>
+      <button type="button" class="cell" data-cell="3" role="gridcell" aria-label="Cell 4"></button>
+      <button type="button" class="cell" data-cell="4" role="gridcell" aria-label="Cell 5"></button>
+      <button type="button" class="cell" data-cell="5" role="gridcell" aria-label="Cell 6"></button>
+      <button type="button" class="cell" data-cell="6" role="gridcell" aria-label="Cell 7"></button>
+      <button type="button" class="cell" data-cell="7" role="gridcell" aria-label="Cell 8"></button>
+      <button type="button" class="cell" data-cell="8" role="gridcell" aria-label="Cell 9"></button>
+    </div>
+  </main>
+  <script src="scripts/gameController.js"></script>
+  <script src="scripts/uiController.js"></script>
+</body>
+</html>

--- a/site/scripts/gameController.js
+++ b/site/scripts/gameController.js
@@ -1,0 +1,111 @@
+(function (global) {
+  const WINNING_COMBINATIONS = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6]
+  ];
+
+  const state = {
+    board: Array(9).fill(null),
+    currentPlayer: "X",
+    startingPlayer: "X",
+    winner: null,
+    moves: 0
+  };
+
+  function isValidPlayer(player) {
+    return player === "X" || player === "O";
+  }
+
+  function reset(options = {}) {
+    const { startingPlayer } = options;
+    if (startingPlayer && isValidPlayer(startingPlayer)) {
+      state.startingPlayer = startingPlayer;
+    }
+
+    state.board.fill(null);
+    state.currentPlayer = state.startingPlayer;
+    state.winner = null;
+    state.moves = 0;
+  }
+
+  function checkWin(player) {
+    return WINNING_COMBINATIONS.some((line) =>
+      line.every((index) => state.board[index] === player)
+    );
+  }
+
+  function makeMove(index) {
+    if (index < 0 || index >= state.board.length) {
+      return { valid: false, reason: "out-of-range" };
+    }
+
+    if (state.board[index] || isGameOver()) {
+      return { valid: false, reason: "occupied" };
+    }
+
+    state.board[index] = state.currentPlayer;
+    state.moves += 1;
+
+    if (checkWin(state.currentPlayer)) {
+      state.winner = state.currentPlayer;
+      return { valid: true, status: "win", player: state.currentPlayer };
+    }
+
+    if (state.moves === state.board.length) {
+      return { valid: true, status: "draw" };
+    }
+
+    state.currentPlayer = state.currentPlayer === "X" ? "O" : "X";
+    return { valid: true, status: "continue", player: state.currentPlayer };
+  }
+
+  function getBoard() {
+    return state.board.slice();
+  }
+
+  function getCurrentPlayer() {
+    return state.currentPlayer;
+  }
+
+  function getStartingPlayer() {
+    return state.startingPlayer;
+  }
+
+  function setStartingPlayer(player) {
+    if (isValidPlayer(player)) {
+      state.startingPlayer = player;
+    }
+  }
+
+  function getWinner() {
+    return state.winner;
+  }
+
+  function isGameOver() {
+    return state.winner !== null || state.moves === state.board.length;
+  }
+
+  function hasActiveGame() {
+    return state.moves > 0 && !isGameOver();
+  }
+
+  global.gameController = {
+    reset,
+    makeMove,
+    getBoard,
+    getCurrentPlayer,
+    getStartingPlayer,
+    setStartingPlayer,
+    getWinner,
+    isGameOver,
+    hasActiveGame
+  };
+
+  reset();
+})(window);

--- a/site/scripts/uiController.js
+++ b/site/scripts/uiController.js
@@ -1,0 +1,140 @@
+(function (global) {
+  const game = global.gameController;
+
+  const elements = {
+    board: null,
+    cells: [],
+    status: null,
+    newGameButton: null,
+    startingPlayerSelect: null
+  };
+
+  const state = {
+    startingPlayer: game.getStartingPlayer()
+  };
+
+  function init() {
+    elements.board = document.querySelector('[data-board]');
+    elements.status = document.querySelector('[data-status]');
+    elements.newGameButton = document.querySelector('[data-action="new-game"]');
+    elements.startingPlayerSelect = document.querySelector('[data-starting-player]');
+
+    if (!elements.board || !elements.status || !elements.newGameButton) {
+      return;
+    }
+
+    elements.cells = Array.from(elements.board.querySelectorAll('[data-cell]'));
+
+    elements.cells.forEach((cell) => {
+      cell.addEventListener('click', handleCellClick);
+    });
+
+    elements.newGameButton.addEventListener('click', handleNewGameClick);
+
+    if (elements.startingPlayerSelect) {
+      elements.startingPlayerSelect.addEventListener('change', handleStartingPlayerChange);
+      state.startingPlayer = elements.startingPlayerSelect.value;
+    }
+
+    startNewGame({ skipPrompt: true });
+  }
+
+  function handleCellClick(event) {
+    const target = event.currentTarget;
+    const cellIndex = Number(target.getAttribute('data-cell'));
+    const result = game.makeMove(cellIndex);
+
+    if (!result.valid) {
+      return;
+    }
+
+    updateBoard();
+
+    if (result.status === 'win') {
+      updateStatus(`Player ${result.player} wins!`);
+    } else if (result.status === 'draw') {
+      updateStatus("It's a draw!");
+    } else {
+      updateStatus(`Player ${game.getCurrentPlayer()}'s turn`);
+    }
+  }
+
+  function handleNewGameClick() {
+    if (game.hasActiveGame() && !global.confirm('A game is currently in progress. Start a new one?')) {
+      return;
+    }
+
+    startNewGame({ skipPrompt: true });
+  }
+
+  function handleStartingPlayerChange(event) {
+    const newPlayer = event.target.value;
+
+    if (newPlayer === state.startingPlayer) {
+      return;
+    }
+
+    const shouldRestart = !game.hasActiveGame() || global.confirm('Switch starting player and restart the game?');
+
+    if (!shouldRestart) {
+      event.target.value = state.startingPlayer;
+      return;
+    }
+
+    state.startingPlayer = newPlayer;
+    startNewGame({ skipPrompt: true });
+  }
+
+  function startNewGame({ skipPrompt = false } = {}) {
+    if (!skipPrompt && game.hasActiveGame()) {
+      const proceed = global.confirm('Start a new game? Your current progress will be lost.');
+      if (!proceed) {
+        if (elements.startingPlayerSelect) {
+          elements.startingPlayerSelect.value = state.startingPlayer;
+        }
+        return;
+      }
+    }
+
+    if (elements.startingPlayerSelect) {
+      state.startingPlayer = elements.startingPlayerSelect.value;
+    }
+
+    game.reset({ startingPlayer: state.startingPlayer });
+    updateBoard();
+    updateStatus(`Player ${state.startingPlayer}'s turn`);
+  }
+
+  function updateBoard() {
+    const board = game.getBoard();
+    const isOver = game.isGameOver();
+
+    board.forEach((value, index) => {
+      const cell = elements.cells[index];
+      if (!cell) {
+        return;
+      }
+
+      cell.textContent = value || '';
+      cell.disabled = Boolean(value) || isOver;
+    });
+  }
+
+  function updateStatus(message) {
+    if (elements.status) {
+      elements.status.textContent = message;
+    }
+  }
+
+  global.uiController = {
+    init,
+    newGame: () => startNewGame({ skipPrompt: true }),
+    updateStatus
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})(window);


### PR DESCRIPTION
## Summary
- create a styled tic tac toe page under `site/` with a controls area and new game button
- implement a game controller to manage turns, wins, draws, and resets
- extend the UI controller to prompt before resetting active games and restore the status message and current player

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68df2b34d524832887ad502e85b5ad70