### PR TITLE
Add configurable player settings to tic tac toe interface

### DIFF
--- a/site/css/styles.css
+++ b/site/css/styles.css
@@ -1,0 +1,319 @@
+:root {
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --panel-border: #334155;
+  --primary: #38bdf8;
+  --accent: #facc15;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --danger: #f87171;
+  --success: #34d399;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.35), transparent 55%),
+    radial-gradient(circle at bottom, rgba(250, 204, 21, 0.25), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.layout {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page-header {
+  text-align: center;
+}
+
+.page-header__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  font-weight: 700;
+}
+
+.page-header__subtitle {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.layout__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.settings,
+.game {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  backdrop-filter: blur(12px);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 18px 50px rgba(2, 12, 27, 0.4);
+}
+
+.settings__title,
+.game__title {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.settings__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.settings__fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.settings__fieldset--inline {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.settings__legend {
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+
+.settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.settings__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.settings__select,
+.settings__choice input {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 1rem;
+  padding: 0.55rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings__select:focus,
+.settings__choice input:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.3);
+}
+
+.settings__choice {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 12px;
+  padding: 0.5rem 0.65rem;
+  background: rgba(148, 163, 184, 0.08);
+  transition: background 0.2s ease;
+}
+
+.settings__choice:hover {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.settings__choice input {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.settings__error {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  background: rgba(248, 113, 113, 0.12);
+  border-left: 4px solid var(--danger);
+  border-radius: 12px;
+  font-size: 0.95rem;
+  color: #fecaca;
+}
+
+.settings__hint {
+  margin: -0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.settings__form[data-invalid="true"] .settings__select {
+  border-color: rgba(248, 113, 113, 0.7);
+}
+
+.game {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.game__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.game__restart {
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  background: linear-gradient(120deg, var(--primary), #0ea5e9);
+  color: #0f172a;
+  padding: 0.6rem 1.3rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.game__restart:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+  transform: none;
+}
+
+.game__restart:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(14, 165, 233, 0.35);
+}
+
+.players {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.player {
+  border-radius: 16px;
+  padding: 1rem 1.15rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.player--active {
+  border-color: var(--accent);
+  box-shadow: 0 10px 30px rgba(250, 204, 21, 0.25);
+  transform: translateY(-2px);
+}
+
+.player__name {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.player__info {
+  margin: 0.4rem 0 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.player__symbol {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.cell {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: clamp(2.5rem, 8vw, 4rem);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.cell:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.3);
+}
+
+.cell:not(:disabled):hover {
+  transform: translateY(-2px);
+  border-color: var(--primary);
+}
+
+.cell:disabled {
+  cursor: default;
+}
+
+.cell--win {
+  background: rgba(52, 211, 153, 0.25);
+  border-color: var(--success);
+  color: #bbf7d0;
+}
+
+.game__status {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.game__pending {
+  margin: -0.4rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.75rem 1rem 2.5rem;
+  }
+
+  .settings,
+  .game {
+    padding: 1.4rem;
+  }
+
+  .board {
+    gap: 0.55rem;
+  }
+
+  .cell {
+    border-radius: 14px;
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <main class="layout">
+    <header class="page-header">
+      <h1 class="page-header__title">Tic Tac Toe</h1>
+      <p class="page-header__subtitle">Play a quick game with custom symbols and starting turns.</p>
+    </header>
+
+    <div class="layout__grid">
+      <section class="settings" aria-labelledby="settings-title">
+        <h2 id="settings-title" class="settings__title">Game settings</h2>
+        <form id="settings-form" class="settings__form" autocomplete="off">
+          <fieldset class="settings__fieldset" aria-describedby="settings-hint">
+            <legend class="settings__legend">Player symbols</legend>
+            <div class="settings__field">
+              <label class="settings__label" for="settings-player1-symbol">Player 1</label>
+              <select id="settings-player1-symbol" name="player1Symbol" class="settings__select"></select>
+            </div>
+            <div class="settings__field">
+              <label class="settings__label" for="settings-player2-symbol">Player 2</label>
+              <select id="settings-player2-symbol" name="player2Symbol" class="settings__select"></select>
+            </div>
+          </fieldset>
+
+          <fieldset class="settings__fieldset settings__fieldset--inline">
+            <legend class="settings__legend">Starting player</legend>
+            <label class="settings__choice">
+              <input type="radio" name="settings-start" value="player1" checked>
+              <span>Player 1</span>
+            </label>
+            <label class="settings__choice">
+              <input type="radio" name="settings-start" value="player2">
+              <span>Player 2</span>
+            </label>
+          </fieldset>
+
+          <p id="settings-error" class="settings__error" role="alert" hidden></p>
+          <p id="settings-hint" class="settings__hint">Changes apply the next time you restart the game.</p>
+        </form>
+      </section>
+
+      <section class="game" aria-labelledby="game-title">
+        <div class="game__header">
+          <h2 id="game-title" class="game__title">Current game</h2>
+          <button type="button" class="game__restart" data-restart>Restart game</button>
+        </div>
+
+        <div class="players">
+          <article class="player" data-player="player1">
+            <h3 class="player__name">Player 1</h3>
+            <p class="player__info">
+              <span class="player__label">Symbol:</span>
+              <span class="player__symbol" data-player-symbol="player1">X</span>
+            </p>
+          </article>
+          <article class="player" data-player="player2">
+            <h3 class="player__name">Player 2</h3>
+            <p class="player__info">
+              <span class="player__label">Symbol:</span>
+              <span class="player__symbol" data-player-symbol="player2">O</span>
+            </p>
+          </article>
+        </div>
+
+        <div class="board" role="grid" aria-label="Tic Tac Toe board" data-board>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 1 Column 1" data-cell data-index="0"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 1 Column 2" data-cell data-index="1"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 1 Column 3" data-cell data-index="2"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 2 Column 1" data-cell data-index="3"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 2 Column 2" data-cell data-index="4"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 2 Column 3" data-cell data-index="5"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 3 Column 1" data-cell data-index="6"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 3 Column 2" data-cell data-index="7"></button>
+          <button type="button" class="cell" role="gridcell" aria-label="Row 3 Column 3" data-cell data-index="8"></button>
+        </div>
+
+        <p class="game__status" aria-live="polite" data-status>Player 1's turn (X)</p>
+        <p class="game__pending" data-settings-pending hidden>Settings changes have been saved for the next game.</p>
+      </section>
+    </div>
+  </main>
+
+  <script type="module" src="./js/app.js"></script>
+</body>
+</html>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -1,0 +1,138 @@
+import { SettingsController } from './ui/settings.js';
+
+const WIN_LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6]
+];
+
+const boardElement = document.querySelector('[data-board]');
+const cells = Array.from(boardElement.querySelectorAll('[data-cell]'));
+const statusElement = document.querySelector('[data-status]');
+const restartButton = document.querySelector('[data-restart]');
+const pendingBanner = document.querySelector('[data-settings-pending]');
+
+const playerPanels = {
+  player1: document.querySelector('[data-player="player1"]'),
+  player2: document.querySelector('[data-player="player2"]')
+};
+
+const playerSymbolElements = {
+  player1: document.querySelector('[data-player-symbol="player1"]'),
+  player2: document.querySelector('[data-player-symbol="player2"]')
+};
+
+const settings = new SettingsController({
+  form: document.querySelector('#settings-form'),
+  player1Select: document.querySelector('#settings-player1-symbol'),
+  player2Select: document.querySelector('#settings-player2-symbol'),
+  startInputs: document.querySelectorAll('input[name="settings-start"]'),
+  errorContainer: document.querySelector('#settings-error')
+});
+
+settings.init();
+
+let boardState = new Array(9).fill(null);
+let currentPlayer = 'player1';
+let gameOver = false;
+
+const players = {
+  player1: { id: 'player1', label: 'Player 1', symbol: 'X' },
+  player2: { id: 'player2', label: 'Player 2', symbol: 'O' }
+};
+
+settings.onChange(({ valid, hasPendingChanges }) => {
+  restartButton.disabled = !valid;
+  pendingBanner.hidden = !hasPendingChanges;
+});
+
+restartButton.addEventListener('click', () => {
+  if (!settings.isValid()) {
+    settings.focusInvalid();
+    return;
+  }
+
+  const snapshot = settings.commitPending();
+  startNewGame(snapshot);
+});
+
+cells.forEach((cell, index) => {
+  cell.dataset.index = index;
+  cell.addEventListener('click', () => handleCellClick(index, cell));
+});
+
+startNewGame(settings.getActiveSettings());
+
+function handleCellClick(index, cell) {
+  if (gameOver || boardState[index]) {
+    return;
+  }
+
+  boardState[index] = currentPlayer;
+  cell.textContent = players[currentPlayer].symbol;
+  cell.dataset.owner = currentPlayer;
+  cell.disabled = true;
+
+  const winLine = findWinningLine(currentPlayer);
+  if (winLine) {
+    gameOver = true;
+    winLine.forEach((position) => {
+      cells[position].classList.add('cell--win');
+    });
+    updateStatus(`${players[currentPlayer].label} wins!`);
+    updateTurnIndicator(null);
+    return;
+  }
+
+  if (boardState.every(Boolean)) {
+    gameOver = true;
+    updateStatus('Draw game.');
+    updateTurnIndicator(null);
+    return;
+  }
+
+  currentPlayer = currentPlayer === 'player1' ? 'player2' : 'player1';
+  updateTurnIndicator(currentPlayer);
+  updateStatus(`${players[currentPlayer].label}'s turn (${players[currentPlayer].symbol})`);
+}
+
+function startNewGame(snapshot = settings.getActiveSettings()) {
+  boardState = new Array(9).fill(null);
+  gameOver = false;
+  currentPlayer = snapshot.starting;
+
+  players.player1.symbol = snapshot.player1.symbol;
+  players.player2.symbol = snapshot.player2.symbol;
+
+  playerSymbolElements.player1.textContent = players.player1.symbol;
+  playerSymbolElements.player2.textContent = players.player2.symbol;
+
+  cells.forEach((cell) => {
+    cell.textContent = '';
+    cell.disabled = false;
+    cell.classList.remove('cell--win');
+    delete cell.dataset.owner;
+  });
+
+  updateTurnIndicator(currentPlayer);
+  updateStatus(`${players[currentPlayer].label}'s turn (${players[currentPlayer].symbol})`);
+}
+
+function findWinningLine(player) {
+  return WIN_LINES.find((line) => line.every((index) => boardState[index] === player)) || null;
+}
+
+function updateTurnIndicator(activePlayer) {
+  Object.entries(playerPanels).forEach(([playerId, panel]) => {
+    panel.classList.toggle('player--active', activePlayer && playerId === activePlayer);
+  });
+}
+
+function updateStatus(message) {
+  statusElement.textContent = message;
+}

--- a/site/js/ui/settings.js
+++ b/site/js/ui/settings.js
@@ -1,0 +1,205 @@
+const SYMBOL_CHOICES = ['X', 'O', '△', '⬤', '★', '⬢'];
+
+const DEFAULT_SETTINGS = Object.freeze({
+  player1: { symbol: 'X' },
+  player2: { symbol: 'O' },
+  starting: 'player1'
+});
+
+const FIELD_KEYS = ['player1', 'player2'];
+
+function cloneSettings(source) {
+  return {
+    player1: { symbol: source.player1.symbol },
+    player2: { symbol: source.player2.symbol },
+    starting: source.starting
+  };
+}
+
+function settingsEqual(a, b) {
+  return (
+    a.starting === b.starting &&
+    a.player1.symbol === b.player1.symbol &&
+    a.player2.symbol === b.player2.symbol
+  );
+}
+
+export class SettingsController {
+  constructor({ form, player1Select, player2Select, startInputs, errorContainer }) {
+    this.form = form;
+    this.selects = {
+      player1: player1Select,
+      player2: player2Select
+    };
+    this.startInputs = Array.from(startInputs || []);
+    this.errorContainer = errorContainer;
+
+    this._listeners = new Set();
+    this._pending = cloneSettings(DEFAULT_SETTINGS);
+    this._active = cloneSettings(DEFAULT_SETTINGS);
+    this._lastChangedField = null;
+  }
+
+  init() {
+    this.#ensureElements();
+    this.#populateSymbolOptions();
+    this._pending = cloneSettings(DEFAULT_SETTINGS);
+    this._active = cloneSettings(DEFAULT_SETTINGS);
+    this.#syncFormFromState();
+    this.#attachListeners();
+    this.#updateIndicators();
+    this.#notify();
+  }
+
+  onChange(listener) {
+    if (typeof listener !== 'function') {
+      return () => {};
+    }
+
+    this._listeners.add(listener);
+    listener(this.#buildPayload());
+
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  getActiveSettings() {
+    return cloneSettings(this._active);
+  }
+
+  getPendingSettings() {
+    return cloneSettings(this._pending);
+  }
+
+  isValid() {
+    return this._pending.player1.symbol !== this._pending.player2.symbol;
+  }
+
+  hasUnappliedChanges() {
+    return !settingsEqual(this._pending, this._active);
+  }
+
+  commitPending() {
+    if (!this.isValid()) {
+      throw new Error('Cannot apply invalid settings.');
+    }
+
+    this._active = this.getPendingSettings();
+    this.#updateIndicators();
+    this.#notify();
+
+    return this.getActiveSettings();
+  }
+
+  focusInvalid() {
+    if (this.isValid()) {
+      return;
+    }
+
+    const fieldKey = this._lastChangedField && FIELD_KEYS.includes(this._lastChangedField)
+      ? this._lastChangedField
+      : 'player2';
+
+    const element = this.selects[fieldKey];
+    if (element) {
+      element.focus();
+    }
+  }
+
+  #ensureElements() {
+    FIELD_KEYS.forEach((key) => {
+      if (!this.selects[key]) {
+        throw new Error(`Missing select element for ${key}`);
+      }
+    });
+
+    if (!this.form) {
+      throw new Error('SettingsController requires a form element.');
+    }
+  }
+
+  #populateSymbolOptions() {
+    FIELD_KEYS.forEach((key) => {
+      const select = this.selects[key];
+      select.innerHTML = '';
+      SYMBOL_CHOICES.forEach((symbol) => {
+        const option = document.createElement('option');
+        option.value = symbol;
+        option.textContent = symbol;
+        select.appendChild(option);
+      });
+    });
+  }
+
+  #attachListeners() {
+    FIELD_KEYS.forEach((key) => {
+      const select = this.selects[key];
+      select.addEventListener('change', (event) => {
+        const value = event.target.value;
+        this._pending[key].symbol = value;
+        this._lastChangedField = key;
+        this.#updateIndicators();
+        this.#notify();
+      });
+    });
+
+    this.startInputs.forEach((input) => {
+      input.addEventListener('change', (event) => {
+        if (!event.target.checked) {
+          return;
+        }
+        this._pending.starting = event.target.value;
+        this._lastChangedField = 'starting';
+        this.#updateIndicators();
+        this.#notify();
+      });
+    });
+  }
+
+  #syncFormFromState() {
+    FIELD_KEYS.forEach((key) => {
+      this.selects[key].value = this._pending[key].symbol;
+    });
+
+    this.startInputs.forEach((input) => {
+      input.checked = input.value === this._pending.starting;
+    });
+  }
+
+  #updateIndicators() {
+    const valid = this.isValid();
+    const hasPending = this.hasUnappliedChanges();
+
+    if (this.form) {
+      this.form.dataset.invalid = String(!valid);
+      this.form.dataset.pending = String(hasPending);
+    }
+
+    if (this.errorContainer) {
+      if (!valid) {
+        this.errorContainer.hidden = false;
+        this.errorContainer.textContent = 'Each player must use a different symbol.';
+      } else {
+        this.errorContainer.hidden = true;
+        this.errorContainer.textContent = '';
+      }
+    }
+  }
+
+  #notify() {
+    const payload = this.#buildPayload();
+    this._listeners.forEach((listener) => {
+      listener(payload);
+    });
+  }
+
+  #buildPayload() {
+    return {
+      active: this.getActiveSettings(),
+      pending: this.getPendingSettings(),
+      valid: this.isValid(),
+      hasPendingChanges: this.hasUnappliedChanges()
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- create a settings panel that lets players pick their symbols and who starts the next round
- implement a settings controller module to validate and persist pending selections until restart
- hook the game restart flow into the controller so new choices apply on restart without interrupting the current game

## Testing
- Manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68df2b374ff08328a0cc64b5482d24ef