### PR TITLE
Add persistent tic tac toe scoreboard with reset control

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tic Tac Toe</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      margin: 0;
+      padding: 40px 10px;
+      background: #f8f8f8;
+    }
+
+    h1 {
+      margin-bottom: 24px;
+      color: #333;
+    }
+
+    .game-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 32px;
+      max-width: 480px;
+      margin: 0 auto;
+    }
+
+    .board {
+      display: inline-block;
+      border-collapse: collapse;
+      background: #fff;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+    }
+
+    .board td {
+      width: 90px;
+      height: 90px;
+      border: 2px solid #ccc;
+      font-size: 48px;
+      text-align: center;
+      vertical-align: middle;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+    }
+
+    .board td:hover {
+      background-color: #f2f2f2;
+    }
+
+    .message {
+      font-size: 20px;
+      font-weight: bold;
+      color: #444;
+      min-height: 24px;
+    }
+
+    .scoreboard {
+      width: 100%;
+      max-width: 320px;
+      background: #fff;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+      text-align: left;
+    }
+
+    .scoreboard h2 {
+      margin-top: 0;
+      margin-bottom: 16px;
+      text-align: center;
+      font-size: 22px;
+      color: #333;
+    }
+
+    .scoreboard-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .scoreboard-list li {
+      display: flex;
+      justify-content: space-between;
+      padding: 8px 0;
+      border-bottom: 1px solid #eee;
+      font-size: 16px;
+    }
+
+    .scoreboard-list li:last-child {
+      border-bottom: none;
+    }
+
+    .reset-scores {
+      margin-top: 20px;
+      width: 100%;
+      padding: 10px 16px;
+      font-size: 16px;
+      border: none;
+      border-radius: 4px;
+      background-color: #1f75fe;
+      color: #fff;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+    }
+
+    .reset-scores:hover,
+    .reset-scores:focus {
+      background-color: #195fcc;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="game-container">
+    <div>
+      <h1>Tic Tac Toe</h1>
+      <table class="board">
+        <tbody>
+          <tr>
+            <td data-row="0" data-col="0"></td>
+            <td data-row="0" data-col="1"></td>
+            <td data-row="0" data-col="2"></td>
+          </tr>
+          <tr>
+            <td data-row="1" data-col="0"></td>
+            <td data-row="1" data-col="1"></td>
+            <td data-row="1" data-col="2"></td>
+          </tr>
+          <tr>
+            <td data-row="2" data-col="0"></td>
+            <td data-row="2" data-col="1"></td>
+            <td data-row="2" data-col="2"></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="message" aria-live="polite"></div>
+    </div>
+
+    <aside class="scoreboard" aria-label="Tic Tac Toe scoreboard">
+      <h2>Scoreboard</h2>
+      <ul class="scoreboard-list">
+        <li>
+          <span>Player X Wins</span>
+          <span id="score-x">0</span>
+        </li>
+        <li>
+          <span>Player O Wins</span>
+          <span id="score-o">0</span>
+        </li>
+        <li>
+          <span>Draws</span>
+          <span id="score-draws">0</span>
+        </li>
+      </ul>
+      <button type="button" class="reset-scores" id="reset-scores">Reset Scores</button>
+    </aside>
+  </div>
+
+  <script src="js/ui/scoreboard.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var currentPlayer = 'X';
+      var board = [
+        ['', '', ''],
+        ['', '', ''],
+        ['', '', '']
+      ];
+      var gameOver = false;
+      var messageElement = document.querySelector('.message');
+      var cells = document.querySelectorAll('.board td');
+      var scoreboard = window.Scoreboard.init({
+        xWinsElement: document.getElementById('score-x'),
+        oWinsElement: document.getElementById('score-o'),
+        drawsElement: document.getElementById('score-draws'),
+        resetButton: document.getElementById('reset-scores')
+      });
+
+      messageElement.textContent = currentPlayer + "'s turn";
+
+      cells.forEach(function (cell) {
+        cell.addEventListener('click', function () {
+          var row = parseInt(cell.getAttribute('data-row'), 10);
+          var col = parseInt(cell.getAttribute('data-col'), 10);
+          makeMove(row, col, cell);
+        });
+      });
+
+      function makeMove(row, col, cellElement) {
+        if (gameOver || board[row][col] !== '') {
+          return;
+        }
+
+        board[row][col] = currentPlayer;
+        cellElement.textContent = currentPlayer;
+
+        if (checkWin(currentPlayer)) {
+          messageElement.textContent = currentPlayer + ' Wins!';
+          gameOver = true;
+          scoreboard.recordWin(currentPlayer);
+        } else if (checkDraw()) {
+          messageElement.textContent = "It's a draw!";
+          gameOver = true;
+          scoreboard.recordDraw();
+        } else {
+          currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+          messageElement.textContent = currentPlayer + "'s turn";
+        }
+      }
+
+      function checkWin(player) {
+        for (var i = 0; i < 3; i++) {
+          if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
+            return true;
+          }
+          if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
+            return true;
+          }
+        }
+
+        if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
+          return true;
+        }
+        if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
+          return true;
+        }
+
+        return false;
+      }
+
+      function checkDraw() {
+        for (var i = 0; i < 3; i++) {
+          for (var j = 0; j < 3; j++) {
+            if (board[i][j] === '') {
+              return false;
+            }
+          }
+        }
+
+        return true;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/site/js/ui/scoreboard.js
+++ b/site/js/ui/scoreboard.js
@@ -1,0 +1,111 @@
+(function () {
+  const STORAGE_KEY = 'tictactoe-scoreboard';
+  let scores = { xWins: 0, oWins: 0, draws: 0 };
+  let elements = { xWins: null, oWins: null, draws: null, resetButton: null };
+  let resetHandler = null;
+
+  function loadScores() {
+    try {
+      const saved = window.localStorage.getItem(STORAGE_KEY);
+      if (!saved) {
+        return { ...scores };
+      }
+      const parsed = JSON.parse(saved);
+      return {
+        xWins: Number.isFinite(parsed.xWins) ? parsed.xWins : 0,
+        oWins: Number.isFinite(parsed.oWins) ? parsed.oWins : 0,
+        draws: Number.isFinite(parsed.draws) ? parsed.draws : 0
+      };
+    } catch (error) {
+      console.warn('Unable to read scoreboard from localStorage:', error);
+      return { ...scores };
+    }
+  }
+
+  function persistScores() {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(scores));
+    } catch (error) {
+      console.warn('Unable to persist scoreboard to localStorage:', error);
+    }
+  }
+
+  function refreshUI() {
+    if (elements.xWins) {
+      elements.xWins.textContent = scores.xWins;
+    }
+    if (elements.oWins) {
+      elements.oWins.textContent = scores.oWins;
+    }
+    if (elements.draws) {
+      elements.draws.textContent = scores.draws;
+    }
+  }
+
+  function bindResetHandler() {
+    if (!elements.resetButton) {
+      return;
+    }
+
+    if (resetHandler) {
+      elements.resetButton.removeEventListener('click', resetHandler);
+    }
+
+    resetHandler = function () {
+      scores = { xWins: 0, oWins: 0, draws: 0 };
+      persistScores();
+      refreshUI();
+    };
+
+    elements.resetButton.addEventListener('click', resetHandler);
+  }
+
+  function init(config) {
+    config = config || {};
+
+    elements = {
+      xWins: config.xWinsElement || null,
+      oWins: config.oWinsElement || null,
+      draws: config.drawsElement || null,
+      resetButton: config.resetButton || null
+    };
+
+    scores = loadScores();
+    refreshUI();
+    bindResetHandler();
+
+    return api;
+  }
+
+  function recordWin(player) {
+    if (player === 'X') {
+      scores.xWins += 1;
+    } else if (player === 'O') {
+      scores.oWins += 1;
+    } else {
+      return;
+    }
+
+    persistScores();
+    refreshUI();
+  }
+
+  function recordDraw() {
+    scores.draws += 1;
+    persistScores();
+    refreshUI();
+  }
+
+  function getScores() {
+    return { ...scores };
+  }
+
+  const api = {
+    init,
+    recordWin,
+    recordDraw,
+    getScores
+  };
+
+  window.Scoreboard = api;
+})();


### PR DESCRIPTION
## Summary
- add a reusable scoreboard module that persists win and draw counts in localStorage
- create a refreshed Tic Tac Toe page with a scoreboard panel and reset control
- hook game completion events into the scoreboard to update tallies and announce the active player

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df2b3854b08328a8dacf9399de21c6