### PR TITLE
Add heuristic AI strategy and orchestrator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,44 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tic Tac Toe</title>
   <style>
     body {
       font-family: Arial, sans-serif;
       text-align: center;
-      margin-top: 100px;
+      margin: 0;
+      padding: 40px 20px;
+      background-color: #f7f7f7;
     }
+
+    h1 {
+      margin-bottom: 10px;
+    }
+
+    .controls {
+      margin-bottom: 20px;
+    }
+
+    .controls label {
+      margin-right: 8px;
+      font-weight: bold;
+    }
+
+    .controls select,
+    .controls button {
+      padding: 6px 12px;
+      font-size: 16px;
+      margin: 0 6px;
+    }
+
     .board {
-      display: inline-block;
+      margin: 0 auto;
       border-collapse: collapse;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     }
+
     .board td {
       width: 100px;
       height: 100px;
@@ -22,98 +47,60 @@
       text-align: center;
       vertical-align: middle;
       cursor: pointer;
+      background-color: #fff;
+      transition: background-color 0.2s ease-in-out;
     }
-    
+
     .board td:hover {
       background-color: #f2f2f2;
     }
-    
+
     .message {
-      margin-top: 20px;
+      margin-top: 25px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 36px;
+    }
+
+    @media (max-width: 480px) {
+      .board td {
+        width: 80px;
+        height: 80px;
+        font-size: 36px;
+      }
     }
   </style>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
+  <h1>Tic Tac Toe</h1>
+  <div class="controls">
+    <label for="aiSelector">AI Strategy:</label>
+    <select id="aiSelector"></select>
+    <button id="resetButton" type="button">Reset</button>
+  </div>
+  <table class="board" id="board">
+    <tbody>
+      <tr>
+        <td data-row="0" data-col="0"></td>
+        <td data-row="0" data-col="1"></td>
+        <td data-row="0" data-col="2"></td>
+      </tr>
+      <tr>
+        <td data-row="1" data-col="0"></td>
+        <td data-row="1" data-col="1"></td>
+        <td data-row="1" data-col="2"></td>
+      </tr>
+      <tr>
+        <td data-row="2" data-col="0"></td>
+        <td data-row="2" data-col="1"></td>
+        <td data-row="2" data-col="2"></td>
+      </tr>
+    </tbody>
   </table>
-  <div class="message"></div>
+  <div class="message" id="message"></div>
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
-          }
-        }
-      }
-      
-      return true;
-    }
-  </script>
+  <script src="site/js/ai/orchestrator.js"></script>
+  <script src="site/js/ai/heuristic.js"></script>
+  <script src="site/js/app.js"></script>
 </body>
 </html>

--- a/site/js/ai/heuristic.js
+++ b/site/js/ai/heuristic.js
@@ -1,0 +1,100 @@
+(function (global) {
+  if (!global || !global.TicTacToeAI) {
+    throw new Error('TicTacToe AI orchestrator is required before loading the heuristic strategy.');
+  }
+
+  var orchestrator = global.TicTacToeAI;
+  var helpers = orchestrator.helpers;
+  var LINES = helpers.getLines();
+  var CORNERS = [
+    [0, 0],
+    [0, 2],
+    [2, 0],
+    [2, 2]
+  ];
+  var SIDES = [
+    [0, 1],
+    [1, 0],
+    [1, 2],
+    [2, 1]
+  ];
+
+  function findCompletingMove(board, player) {
+    for (var i = 0; i < LINES.length; i++) {
+      var line = LINES[i];
+      var playerCount = 0;
+      var emptyCell = null;
+      var blocked = false;
+
+      for (var j = 0; j < line.length; j++) {
+        var position = line[j];
+        var row = position[0];
+        var col = position[1];
+        var cellValue = board[row][col];
+
+        if (cellValue === player) {
+          playerCount += 1;
+        } else if (cellValue === '') {
+          emptyCell = position;
+        } else {
+          blocked = true;
+          break;
+        }
+      }
+
+      if (!blocked && playerCount === 2 && emptyCell) {
+        return {
+          row: emptyCell[0],
+          col: emptyCell[1]
+        };
+      }
+    }
+
+    return null;
+  }
+
+  function pickFromList(board, cells) {
+    for (var i = 0; i < cells.length; i++) {
+      var row = cells[i][0];
+      var col = cells[i][1];
+      if (board[row][col] === '') {
+        return { row: row, col: col };
+      }
+    }
+
+    return null;
+  }
+
+  function getMove(context) {
+    var board = context.board;
+    var player = context.player;
+    var opponent = context.opponent;
+
+    var winningMove = findCompletingMove(board, player);
+    if (winningMove) {
+      return winningMove;
+    }
+
+    var blockingMove = findCompletingMove(board, opponent);
+    if (blockingMove) {
+      return blockingMove;
+    }
+
+    if (board[1][1] === '') {
+      return { row: 1, col: 1 };
+    }
+
+    var cornerMove = pickFromList(board, CORNERS);
+    if (cornerMove) {
+      return cornerMove;
+    }
+
+    return pickFromList(board, SIDES);
+  }
+
+  orchestrator.registerStrategy({
+    id: 'heuristic',
+    label: 'Heuristic (Win/Block)',
+    getMove: getMove
+  });
+})(typeof window !== 'undefined' ? window : null);

--- a/site/js/ai/orchestrator.js
+++ b/site/js/ai/orchestrator.js
@@ -1,0 +1,174 @@
+(function (global) {
+  if (!global) {
+    throw new Error('Global object not found for TicTacToe AI orchestrator.');
+  }
+
+  var LINES = [
+    [ [0, 0], [0, 1], [0, 2] ],
+    [ [1, 0], [1, 1], [1, 2] ],
+    [ [2, 0], [2, 1], [2, 2] ],
+    [ [0, 0], [1, 0], [2, 0] ],
+    [ [0, 1], [1, 1], [2, 1] ],
+    [ [0, 2], [1, 2], [2, 2] ],
+    [ [0, 0], [1, 1], [2, 2] ],
+    [ [0, 2], [1, 1], [2, 0] ]
+  ];
+
+  var strategies = new Map();
+  var defaultStrategyId = null;
+
+  function cloneBoard(board) {
+    return board.map(function (row) {
+      return row.slice();
+    });
+  }
+
+  function getOpponent(player) {
+    return player === 'X' ? 'O' : 'X';
+  }
+
+  function isValidBoard(board) {
+    if (!Array.isArray(board) || board.length !== 3) {
+      return false;
+    }
+
+    return board.every(function (row) {
+      return Array.isArray(row) && row.length === 3;
+    });
+  }
+
+  function isCellEmpty(board, row, col) {
+    return board[row] && board[row][col] === '';
+  }
+
+  function cloneLines() {
+    return LINES.map(function (line) {
+      return line.slice();
+    });
+  }
+
+  var helperAPI = {
+    getLines: function () {
+      return cloneLines();
+    },
+    cloneBoard: cloneBoard,
+    getOpponent: getOpponent,
+    isCellEmpty: isCellEmpty
+  };
+
+  function validateStrategy(strategy) {
+    if (!strategy || typeof strategy !== 'object') {
+      throw new Error('Strategy must be an object.');
+    }
+    if (!strategy.id || typeof strategy.id !== 'string') {
+      throw new Error('Strategy id must be a non-empty string.');
+    }
+    if (typeof strategy.getMove !== 'function') {
+      throw new Error('Strategy getMove must be a function.');
+    }
+  }
+
+  function registerStrategy(strategy) {
+    validateStrategy(strategy);
+
+    if (strategies.has(strategy.id)) {
+      console.warn('Strategy with id "' + strategy.id + '" is already registered. Overwriting existing strategy.');
+    }
+
+    strategies.set(strategy.id, {
+      id: strategy.id,
+      label: strategy.label || strategy.id,
+      getMove: strategy.getMove
+    });
+
+    if (!defaultStrategyId) {
+      defaultStrategyId = strategy.id;
+    }
+  }
+
+  function chooseMove(options) {
+    options = options || {};
+    var board = options.board;
+    var player = options.player;
+    var strategyId = options.strategyId || defaultStrategyId;
+    var opponent = options.opponent || getOpponent(player);
+
+    if (!strategyId || !strategies.has(strategyId)) {
+      console.warn('Unknown strategy "' + strategyId + '".');
+      return null;
+    }
+
+    if (!isValidBoard(board) || !player) {
+      console.warn('Invalid board or player supplied to chooseMove.');
+      return null;
+    }
+
+    var strategy = strategies.get(strategyId);
+    var safeBoard = cloneBoard(board);
+    var move = strategy.getMove({
+      board: safeBoard,
+      player: player,
+      opponent: opponent,
+      helpers: helperAPI
+    });
+
+    if (!move) {
+      return null;
+    }
+
+    var row = move.row;
+    var col = move.col;
+
+    if (typeof row !== 'number' || typeof col !== 'number') {
+      console.warn('Strategy "' + strategyId + '" returned an invalid move format.');
+      return null;
+    }
+
+    if (row < 0 || row > 2 || col < 0 || col > 2) {
+      console.warn('Strategy "' + strategyId + '" returned an out-of-bounds move.');
+      return null;
+    }
+
+    if (!isCellEmpty(board, row, col)) {
+      console.warn('Strategy "' + strategyId + '" returned a move for an occupied cell.');
+      return null;
+    }
+
+    return { row: row, col: col };
+  }
+
+  function listStrategies() {
+    return Array.from(strategies.values()).map(function (strategy) {
+      return {
+        id: strategy.id,
+        label: strategy.label
+      };
+    });
+  }
+
+  function setDefaultStrategyId(strategyId) {
+    if (!strategies.has(strategyId)) {
+      throw new Error('Unknown strategy id "' + strategyId + '".');
+    }
+
+    defaultStrategyId = strategyId;
+  }
+
+  function getDefaultStrategyId() {
+    return defaultStrategyId;
+  }
+
+  function getStrategy(strategyId) {
+    return strategies.get(strategyId) || null;
+  }
+
+  global.TicTacToeAI = {
+    registerStrategy: registerStrategy,
+    chooseMove: chooseMove,
+    listStrategies: listStrategies,
+    setDefaultStrategyId: setDefaultStrategyId,
+    getDefaultStrategyId: getDefaultStrategyId,
+    getStrategy: getStrategy,
+    helpers: helperAPI
+  };
+})(typeof window !== 'undefined' ? window : null);

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -1,0 +1,206 @@
+(function (global) {
+  if (!global || !global.document) {
+    throw new Error('A browser-like environment is required to run the Tic Tac Toe app.');
+  }
+
+  var document = global.document;
+  var aiOrchestrator = global.TicTacToeAI;
+
+  if (!aiOrchestrator) {
+    throw new Error('TicTacToeAI orchestrator must be loaded before the app.');
+  }
+
+  var boardElement = document.getElementById('board');
+  var cells = boardElement ? boardElement.querySelectorAll('td') : [];
+  var cellList = Array.prototype.slice.call(cells);
+  var messageElement = document.getElementById('message');
+  var resetButton = document.getElementById('resetButton');
+  var aiSelector = document.getElementById('aiSelector');
+
+  if (!boardElement || cellList.length !== 9 || !messageElement || !resetButton || !aiSelector) {
+    throw new Error('Required game elements are missing from the DOM.');
+  }
+
+  var boardState = createEmptyBoard();
+  var currentPlayer = 'X';
+  var gameOver = false;
+  var selectedStrategyId = aiOrchestrator.getDefaultStrategyId();
+  var lines = aiOrchestrator.helpers.getLines();
+
+  function createEmptyBoard() {
+    return [
+      ['', '', ''],
+      ['', '', ''],
+      ['', '', '']
+    ];
+  }
+
+  function init() {
+    populateStrategySelector();
+    attachCellListeners();
+    resetButton.addEventListener('click', resetGame);
+    aiSelector.addEventListener('change', handleStrategyChange);
+    updateTurnMessage();
+  }
+
+  function populateStrategySelector() {
+    var strategies = aiOrchestrator.listStrategies();
+    aiSelector.innerHTML = '';
+
+    strategies.forEach(function (strategy) {
+      var option = document.createElement('option');
+      option.value = strategy.id;
+      option.textContent = strategy.label;
+      aiSelector.appendChild(option);
+    });
+
+    if (selectedStrategyId) {
+      aiSelector.value = selectedStrategyId;
+    }
+  }
+
+  function attachCellListeners() {
+    cellList.forEach(function (cell) {
+      cell.addEventListener('click', handleCellClick);
+    });
+  }
+
+  function handleStrategyChange(event) {
+    selectedStrategyId = event.target.value;
+    aiOrchestrator.setDefaultStrategyId(selectedStrategyId);
+    if (!gameOver && currentPlayer === 'O') {
+      takeAiTurn();
+    }
+  }
+
+  function handleCellClick(event) {
+    if (gameOver || currentPlayer !== 'X') {
+      return;
+    }
+
+    var cell = event.currentTarget;
+    var row = parseInt(cell.getAttribute('data-row'), 10);
+    var col = parseInt(cell.getAttribute('data-col'), 10);
+
+    if (boardState[row][col] !== '') {
+      return;
+    }
+
+    playMove(row, col, 'X');
+
+    if (checkWin('X')) {
+      endGame('X');
+      return;
+    }
+
+    if (checkDraw()) {
+      endGame('draw');
+      return;
+    }
+
+    currentPlayer = 'O';
+    updateTurnMessage();
+    takeAiTurn();
+  }
+
+  function playMove(row, col, player) {
+    boardState[row][col] = player;
+    var selector = 'td[data-row="' + row + '"][data-col="' + col + '"]';
+    var targetCell = boardElement.querySelector(selector);
+    if (targetCell) {
+      targetCell.textContent = player;
+    }
+  }
+
+  function takeAiTurn() {
+    if (gameOver) {
+      return;
+    }
+
+    var move = aiOrchestrator.chooseMove({
+      board: boardState,
+      player: 'O',
+      strategyId: selectedStrategyId,
+      opponent: 'X'
+    });
+
+    if (!move) {
+      if (checkDraw()) {
+        endGame('draw');
+      } else {
+        console.warn('AI did not return a valid move.');
+      }
+      return;
+    }
+
+    playMove(move.row, move.col, 'O');
+
+    if (checkWin('O')) {
+      endGame('O');
+      return;
+    }
+
+    if (checkDraw()) {
+      endGame('draw');
+      return;
+    }
+
+    currentPlayer = 'X';
+    updateTurnMessage();
+  }
+
+  function checkWin(player) {
+    return lines.some(function (line) {
+      return line.every(function (position) {
+        var row = position[0];
+        var col = position[1];
+        return boardState[row][col] === player;
+      });
+    });
+  }
+
+  function checkDraw() {
+    for (var row = 0; row < 3; row++) {
+      for (var col = 0; col < 3; col++) {
+        if (boardState[row][col] === '') {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  function endGame(result) {
+    gameOver = true;
+    if (result === 'draw') {
+      messageElement.textContent = "It's a draw!";
+    } else {
+      messageElement.textContent = result + ' wins!';
+    }
+  }
+
+  function updateTurnMessage() {
+    if (gameOver) {
+      return;
+    }
+
+    if (currentPlayer === 'X') {
+      messageElement.textContent = 'Your turn (X)';
+    } else {
+      messageElement.textContent = 'AI thinking...';
+    }
+  }
+
+  function resetGame() {
+    boardState = createEmptyBoard();
+    currentPlayer = 'X';
+    gameOver = false;
+    cellList.forEach(function (cell) {
+      cell.textContent = '';
+    });
+    updateTurnMessage();
+  }
+
+  init();
+})(typeof window !== 'undefined' ? window : null);


### PR DESCRIPTION
## Summary
- add a shared Tic Tac Toe AI orchestrator for registering and executing strategies
- implement a deterministic heuristic AI that prioritizes wins, blocks, center, corners, then sides
- refresh the UI to load the orchestrated AI and expose strategy selection with reset support

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df2b3b27748328b95ce87a2f501bb5