### PR TITLE
Add undo/redo support with move history

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -8,12 +6,20 @@
     body {
       font-family: Arial, sans-serif;
       text-align: center;
-      margin-top: 100px;
+      margin-top: 60px;
+      color: #333;
     }
+
+    h1 {
+      margin-bottom: 20px;
+    }
+
     .board {
       display: inline-block;
       border-collapse: collapse;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     }
+
     .board td {
       width: 100px;
       height: 100px;
@@ -22,98 +28,92 @@
       text-align: center;
       vertical-align: middle;
       cursor: pointer;
+      transition: background-color 0.2s ease-in-out;
     }
-    
+
     .board td:hover {
       background-color: #f2f2f2;
     }
-    
+
     .message {
       margin-top: 20px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 28px;
+    }
+
+    .turn {
+      margin-top: 10px;
+      font-size: 18px;
+      color: #666;
+      min-height: 22px;
+    }
+
+    .controls {
+      margin-top: 25px;
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+    }
+
+    .controls button {
+      padding: 10px 18px;
+      font-size: 16px;
+      border: none;
+      border-radius: 4px;
+      background-color: #007bff;
+      color: #fff;
+      cursor: pointer;
+      transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out;
+    }
+
+    .controls button:disabled {
+      background-color: #9fbff2;
+      cursor: not-allowed;
+    }
+
+    .controls button:not(:disabled):hover {
+      background-color: #0069d9;
+    }
+
+    .controls button:not(:disabled):active {
+      transform: scale(0.98);
+    }
+
+    .shortcuts {
+      margin-top: 12px;
+      font-size: 14px;
+      color: #777;
     }
   </style>
 </head>
 <body>
+  <h1>Tic Tac Toe</h1>
   <table class="board">
     <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
+      <td></td>
+      <td></td>
+      <td></td>
     </tr>
     <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
+      <td></td>
+      <td></td>
+      <td></td>
     </tr>
     <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
+      <td></td>
+      <td></td>
+      <td></td>
     </tr>
   </table>
   <div class="message"></div>
+  <div class="turn"></div>
+  <div class="controls">
+    <button type="button" data-action="undo" disabled>Undo (Ctrl+Z)</button>
+    <button type="button" data-action="redo" disabled>Redo (Ctrl+Y)</button>
+  </div>
+  <div class="shortcuts">Use Ctrl+Z / Ctrl+Y to undo or redo moves.</div>
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
-          }
-        }
-      }
-      
-      return true;
-    }
-  </script>
+  <script type="module" src="site/js/main.js"></script>
 </body>
 </html>

--- a/site/js/core/history.js
+++ b/site/js/core/history.js
@@ -1,0 +1,68 @@
+const cloneBoard = (board) => board.map((row) => row.slice());
+
+const cloneState = (state) => ({
+  board: cloneBoard(state.board),
+  currentPlayer: state.currentPlayer,
+  message: state.message,
+  gameOver: state.gameOver,
+});
+
+export class History {
+  constructor(initialState) {
+    this._states = [];
+    this._index = -1;
+    if (initialState) {
+      this.reset(initialState);
+    }
+  }
+
+  push(state) {
+    const snapshot = cloneState(state);
+    if (this._index < this._states.length - 1) {
+      this._states.splice(this._index + 1);
+    }
+    this._states.push(snapshot);
+    this._index = this._states.length - 1;
+    return this.current();
+  }
+
+  undo() {
+    if (!this.canUndo()) {
+      return this.current();
+    }
+    this._index -= 1;
+    return this.current();
+  }
+
+  redo() {
+    if (!this.canRedo()) {
+      return this.current();
+    }
+    this._index += 1;
+    return this.current();
+  }
+
+  current() {
+    if (this._index === -1) {
+      return null;
+    }
+    return cloneState(this._states[this._index]);
+  }
+
+  canUndo() {
+    return this._index > 0;
+  }
+
+  canRedo() {
+    return this._index >= 0 && this._index < this._states.length - 1;
+  }
+
+  reset(initialState) {
+    this._states = [cloneState(initialState)];
+    this._index = 0;
+  }
+}
+
+export const __testUtils = {
+  cloneState,
+};

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,0 +1,125 @@
+import { History } from './core/history.js';
+import { createUIController } from './uiController.js';
+
+const createInitialState = () => ({
+  board: Array.from({ length: 3 }, () => Array(3).fill('')),
+  currentPlayer: 'X',
+  message: '',
+  gameOver: false,
+});
+
+const cloneBoard = (board) => board.map((row) => row.slice());
+
+const calculateMessage = (state) => state.message || '';
+
+const checkWin = (board, player) => {
+  for (let i = 0; i < 3; i += 1) {
+    if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
+      return true;
+    }
+
+    if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
+      return true;
+    }
+  }
+
+  if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
+    return true;
+  }
+
+  if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
+    return true;
+  }
+
+  return false;
+};
+
+const checkDraw = (board) => board.every((row) => row.every((cell) => cell !== ''));
+
+document.addEventListener('DOMContentLoaded', () => {
+  const ui = createUIController({
+    onCellClick: handleCellClick,
+    onUndo: handleUndo,
+    onRedo: handleRedo,
+  });
+
+  const initialState = createInitialState();
+  const history = new History(initialState);
+  let state = initialState;
+
+  function syncUI() {
+    ui.renderBoard(state.board);
+    ui.setMessage(calculateMessage(state));
+    ui.setTurn(state.gameOver ? '' : `Current Player: ${state.currentPlayer}`);
+    ui.setUndoEnabled(history.canUndo());
+    ui.setRedoEnabled(history.canRedo());
+  }
+
+  function applyState(newState, { record = false } = {}) {
+    state = {
+      board: cloneBoard(newState.board),
+      currentPlayer: newState.currentPlayer,
+      message: newState.message,
+      gameOver: newState.gameOver,
+    };
+
+    if (record) {
+      history.push(state);
+    }
+
+    syncUI();
+  }
+
+  function handleCellClick(row, col) {
+    if (state.gameOver || state.board[row][col] !== '') {
+      return;
+    }
+
+    const board = cloneBoard(state.board);
+    board[row][col] = state.currentPlayer;
+
+    let nextPlayer = state.currentPlayer;
+    let message = '';
+    let gameOver = false;
+
+    if (checkWin(board, state.currentPlayer)) {
+      message = `${state.currentPlayer} Wins!`;
+      gameOver = true;
+    } else if (checkDraw(board)) {
+      message = "It's a draw!";
+      gameOver = true;
+    } else {
+      nextPlayer = state.currentPlayer === 'X' ? 'O' : 'X';
+    }
+
+    applyState(
+      {
+        board,
+        currentPlayer: nextPlayer,
+        message,
+        gameOver,
+      },
+      { record: true },
+    );
+  }
+
+  function handleUndo() {
+    if (!history.canUndo()) {
+      return;
+    }
+
+    state = history.undo();
+    syncUI();
+  }
+
+  function handleRedo() {
+    if (!history.canRedo()) {
+      return;
+    }
+
+    state = history.redo();
+    syncUI();
+  }
+
+  syncUI();
+});

--- a/site/js/uiController.js
+++ b/site/js/uiController.js
@@ -1,0 +1,81 @@
+const getKey = (event) => event.key?.toLowerCase?.() || '';
+
+export function createUIController({ onCellClick, onUndo, onRedo }) {
+  const boardElement = document.querySelector('.board');
+  const messageElement = document.querySelector('.message');
+  const turnElement = document.querySelector('.turn');
+  const undoButton = document.querySelector('[data-action="undo"]');
+  const redoButton = document.querySelector('[data-action="redo"]');
+
+  Array.from(boardElement.rows).forEach((rowElement, rowIndex) => {
+    Array.from(rowElement.cells).forEach((cellElement, colIndex) => {
+      cellElement.dataset.row = rowIndex;
+      cellElement.dataset.col = colIndex;
+      cellElement.addEventListener('click', () => {
+        if (typeof onCellClick === 'function') {
+          onCellClick(rowIndex, colIndex);
+        }
+      });
+    });
+  });
+
+  undoButton.addEventListener('click', () => {
+    if (!undoButton.disabled && typeof onUndo === 'function') {
+      onUndo();
+    }
+  });
+
+  redoButton.addEventListener('click', () => {
+    if (!redoButton.disabled && typeof onRedo === 'function') {
+      onRedo();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (!(event.ctrlKey || event.metaKey)) {
+      return;
+    }
+
+    const key = getKey(event);
+    if (key === 'z' && !undoButton.disabled) {
+      event.preventDefault();
+      if (typeof onUndo === 'function') {
+        onUndo();
+      }
+      return;
+    }
+
+    if ((key === 'y' || (key === 'z' && event.shiftKey)) && !redoButton.disabled) {
+      event.preventDefault();
+      if (typeof onRedo === 'function') {
+        onRedo();
+      }
+    }
+  });
+
+  return {
+    renderBoard(board) {
+      Array.from(boardElement.rows).forEach((rowElement, rowIndex) => {
+        Array.from(rowElement.cells).forEach((cellElement, colIndex) => {
+          cellElement.textContent = board[rowIndex][colIndex];
+        });
+      });
+    },
+
+    setMessage(text) {
+      messageElement.textContent = text;
+    },
+
+    setTurn(text) {
+      turnElement.textContent = text;
+    },
+
+    setUndoEnabled(enabled) {
+      undoButton.disabled = !enabled;
+    },
+
+    setRedoEnabled(enabled) {
+      redoButton.disabled = !enabled;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a history helper to snapshot game state and provide undo/redo navigation
- refactor the Tic Tac Toe UI to use a controller that wires board events, buttons, and shortcuts
- refresh the page layout with controls and status indicators that stay in sync with history

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68df2b3526cc8328a2e880d6bc466dcc