### PR TITLE
Add animated mark placement and win highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
-
-
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="site/css/animations.css">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -23,11 +23,11 @@
       vertical-align: middle;
       cursor: pointer;
     }
-    
+
     .board td:hover {
       background-color: #f2f2f2;
     }
-    
+
     .message {
       margin-top: 20px;
       font-size: 24px;
@@ -63,46 +63,73 @@
       ['', '', '']
     ];
     var gameOver = false;
-    
+    var boardElement = document.querySelector('.board');
+    var messageElement = document.querySelector('.message');
+
     function makeMove(row, col) {
       if (gameOver || board[row][col] !== '') {
         return;
       }
-      
+
       board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
+      var cell = boardElement.rows[row].cells[col];
+      cell.textContent = currentPlayer;
+      cell.classList.add('marked', 'marked-' + currentPlayer.toLowerCase());
+
+      var winningLine = checkWin(currentPlayer);
+
+      if (winningLine) {
+        highlightWinningLine(winningLine);
+        messageElement.textContent = currentPlayer + ' Wins!';
         gameOver = true;
       } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
+        messageElement.textContent = "It's a draw!";
         gameOver = true;
       } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
       }
     }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
+
+    function highlightWinningLine(line) {
+      for (var i = 0; i < line.length; i++) {
+        var position = line[i];
+        var cell = boardElement.rows[position[0]].cells[position[1]];
+        cell.classList.add('win-line');
       }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
     }
-    
+
+    function checkWin(player) {
+      var lines = [
+        [[0, 0], [0, 1], [0, 2]],
+        [[1, 0], [1, 1], [1, 2]],
+        [[2, 0], [2, 1], [2, 2]],
+        [[0, 0], [1, 0], [2, 0]],
+        [[0, 1], [1, 1], [2, 1]],
+        [[0, 2], [1, 2], [2, 2]],
+        [[0, 0], [1, 1], [2, 2]],
+        [[0, 2], [1, 1], [2, 0]]
+      ];
+
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var hasWinner = true;
+
+        for (var j = 0; j < line.length; j++) {
+          var position = line[j];
+          if (board[position[0]][position[1]] !== player) {
+            hasWinner = false;
+            break;
+          }
+        }
+
+        if (hasWinner) {
+          return line;
+        }
+      }
+
+      return null;
+    }
+
     function checkDraw() {
       for (var i = 0; i < 3; i++) {
         for (var j = 0; j < 3; j++) {
@@ -111,7 +138,7 @@
           }
         }
       }
-      
+
       return true;
     }
   </script>

--- a/site/css/animations.css
+++ b/site/css/animations.css
@@ -1,0 +1,60 @@
+.board td {
+  position: relative;
+  transition: background-color 0.3s ease;
+}
+
+.board td.marked {
+  animation: mark-pop 250ms ease-out;
+}
+
+.board td.marked-x {
+  color: #ff4d4f;
+}
+
+.board td.marked-o {
+  color: #1890ff;
+}
+
+.board td.win-line {
+  animation: win-glow 1400ms ease-in-out infinite;
+  background-color: rgba(255, 215, 0, 0.25);
+  box-shadow: 0 0 0 rgba(255, 215, 0, 0.6);
+}
+
+@keyframes mark-pop {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes win-glow {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 215, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(255, 215, 0, 0.9);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 215, 0, 0.6);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board td {
+    transition: none;
+  }
+
+  .board td.marked,
+  .board td.win-line {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated CSS for mark entry animations and winning-line highlights with reduced motion support
- update tic-tac-toe game logic to add mark and highlight classes when moves and wins occur

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68df2b411fa08328857bf3b0dc96dfdc