### PR TITLE
Add accessible settings modal to Tic Tac Toe UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,119 +1,175 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="site/css/modal.css" />
   <style>
+    :root {
+      color-scheme: light dark;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    }
+
     body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
+      margin: 0;
+      padding: 24px;
+      background: radial-gradient(circle at top, #f8f9ff, #f1f3f9);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
     }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
+
+    header {
+      display: flex;
+      width: min(90vw, 640px);
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
     }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2.5vw, 2.5rem);
+      color: #0d1b2a;
+    }
+
+    .settings-button {
+      border: none;
+      background-color: #0d6efd;
+      color: #fff;
+      padding: 10px 16px;
+      border-radius: 999px;
+      font-weight: 600;
       cursor: pointer;
+      transition: background-color 0.2s ease;
     }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
+
+    .settings-button:hover,
+    .settings-button:focus {
+      background-color: #0b5ed7;
     }
-    
+
+    main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .board {
+      border-collapse: collapse;
+      border-spacing: 0;
+      background: #ffffff;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+    }
+
+    .board td {
+      border: 2px solid #d7dde9;
+      padding: 0;
+    }
+
+    .board button {
+      width: 110px;
+      height: 110px;
+      font-size: 2.5rem;
+      font-weight: 700;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background-color 0.2s ease, transform 0.2s ease;
+      display: grid;
+      place-items: center;
+    }
+
+    .board button:hover:not(:disabled),
+    .board button:focus-visible:not(:disabled) {
+      background-color: rgba(13, 110, 253, 0.12);
+      transform: scale(1.02);
+    }
+
+    .board button:disabled {
+      cursor: default;
+      color: #0d1b2a;
+    }
+
+    .board button.cell--winning {
+      background-color: rgba(25, 135, 84, 0.2);
+      color: #198754;
+    }
+
     .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
+      font-size: 1.4rem;
+      font-weight: 600;
+      color: #0d1b2a;
+      min-height: 1.4rem;
+    }
+
+    @media (max-width: 600px) {
+      body {
+        padding: 16px;
+      }
+
+      .board button {
+        width: 90px;
+        height: 90px;
+        font-size: 2rem;
+      }
     }
   </style>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <header>
+    <h1>Tic Tac Toe</h1>
+    <button type="button" class="settings-button" data-modal-trigger="settings-modal">Settings</button>
+  </header>
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
-          }
-        }
-      }
-      
-      return true;
-    }
-  </script>
+  <main>
+    <table class="board" role="grid" aria-label="Tic Tac Toe board">
+      <tbody>
+        <tr>
+          <td><button type="button" data-cell="0-0" aria-label="Row 1 column 1"></button></td>
+          <td><button type="button" data-cell="0-1" aria-label="Row 1 column 2"></button></td>
+          <td><button type="button" data-cell="0-2" aria-label="Row 1 column 3"></button></td>
+        </tr>
+        <tr>
+          <td><button type="button" data-cell="1-0" aria-label="Row 2 column 1"></button></td>
+          <td><button type="button" data-cell="1-1" aria-label="Row 2 column 2"></button></td>
+          <td><button type="button" data-cell="1-2" aria-label="Row 2 column 3"></button></td>
+        </tr>
+        <tr>
+          <td><button type="button" data-cell="2-0" aria-label="Row 3 column 1"></button></td>
+          <td><button type="button" data-cell="2-1" aria-label="Row 3 column 2"></button></td>
+          <td><button type="button" data-cell="2-2" aria-label="Row 3 column 3"></button></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="message" aria-live="polite"></div>
+  </main>
+
+  <div class="modal" id="settings-modal" data-modal aria-hidden="true">
+    <div class="modal__backdrop" data-modal-overlay></div>
+    <div class="modal__dialog" data-modal-dialog aria-labelledby="settings-title">
+      <button type="button" class="modal__close" aria-label="Close settings" data-modal-close>&times;</button>
+      <h2 class="modal__title" id="settings-title">Game Settings</h2>
+      <form id="settings-form" class="modal__form">
+        <label class="modal__label" for="starting-player">
+          Starting player
+          <select id="starting-player" class="modal__select">
+            <option value="X">Player X</option>
+            <option value="O">Player O</option>
+          </select>
+        </label>
+        <button type="submit" class="modal__primary">Start new game</button>
+        <button type="button" id="reset-button" class="modal__secondary">Reset board</button>
+      </form>
+    </div>
+  </div>
+
+  <script type="module" src="site/js/main.js"></script>
 </body>
 </html>

--- a/site/css/modal.css
+++ b/site/css/modal.css
@@ -1,0 +1,118 @@
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 1000;
+}
+
+.modal--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(17, 17, 17, 0.6);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.modal--visible .modal__backdrop {
+  opacity: 1;
+}
+
+.modal__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(90vw, 420px);
+  max-height: 90vh;
+  overflow-y: auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.2);
+  padding: 24px;
+  transform: translateY(32px);
+  transition: transform 0.25s ease;
+}
+
+.modal--visible .modal__dialog {
+  transform: translateY(0);
+}
+
+.modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #555;
+}
+
+.modal__close:hover,
+.modal__close:focus {
+  color: #111;
+}
+
+.modal__title {
+  margin: 0 0 16px;
+  font-size: 1.5rem;
+}
+
+.modal__form {
+  display: grid;
+  gap: 16px;
+}
+
+.modal__label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.modal__select,
+.modal__primary,
+.modal__secondary {
+  font-size: 1rem;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.modal__primary {
+  background-color: #0d6efd;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  text-align: center;
+}
+
+.modal__primary:hover,
+.modal__primary:focus {
+  background-color: #0b5ed7;
+}
+
+.modal__secondary {
+  background-color: #f8f9fa;
+  border: 1px solid #ced4da;
+  color: #1b1f24;
+  cursor: pointer;
+  font-weight: 600;
+  text-align: center;
+}
+
+.modal__secondary:hover,
+.modal__secondary:focus {
+  background-color: #e2e6ea;
+}

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,0 +1,150 @@
+import { initModals } from './ui/modal.js';
+
+const modalMap = initModals();
+const settingsModal = modalMap.get('settings-modal');
+
+const boardElement = document.querySelector('.board');
+const messageElement = document.querySelector('.message');
+const settingsForm = document.getElementById('settings-form');
+const startingPlayerSelect = document.getElementById('starting-player');
+
+let boardState = [];
+let currentPlayer = startingPlayerSelect ? startingPlayerSelect.value : 'X';
+let gameOver = false;
+
+function createEmptyBoard() {
+  return Array.from({ length: 3 }, () => ['', '', '']);
+}
+
+function resetBoardElements() {
+  const cells = boardElement.querySelectorAll('[data-cell]');
+  cells.forEach((cell) => {
+    cell.textContent = '';
+    cell.classList.remove('cell--winning');
+    cell.disabled = false;
+  });
+}
+
+function resetGame({ startingPlayer } = {}) {
+  boardState = createEmptyBoard();
+  const nextStartingPlayer = startingPlayer
+    || (startingPlayerSelect ? startingPlayerSelect.value : currentPlayer);
+  currentPlayer = nextStartingPlayer;
+  if (startingPlayerSelect) {
+    startingPlayerSelect.value = currentPlayer;
+  }
+  gameOver = false;
+  messageElement.textContent = `${currentPlayer}'s turn`;
+  resetBoardElements();
+}
+
+function getCellCoordinates(cell) {
+  return cell.getAttribute('data-cell').split('-').map(Number);
+}
+
+function checkWin(player) {
+  for (let i = 0; i < 3; i += 1) {
+    if (boardState[i][0] === player && boardState[i][1] === player && boardState[i][2] === player) {
+      return [
+        [i, 0],
+        [i, 1],
+        [i, 2]
+      ];
+    }
+
+    if (boardState[0][i] === player && boardState[1][i] === player && boardState[2][i] === player) {
+      return [
+        [0, i],
+        [1, i],
+        [2, i]
+      ];
+    }
+  }
+
+  if (boardState[0][0] === player && boardState[1][1] === player && boardState[2][2] === player) {
+    return [
+      [0, 0],
+      [1, 1],
+      [2, 2]
+    ];
+  }
+
+  if (boardState[0][2] === player && boardState[1][1] === player && boardState[2][0] === player) {
+    return [
+      [0, 2],
+      [1, 1],
+      [2, 0]
+    ];
+  }
+
+  return null;
+}
+
+function checkDraw() {
+  return boardState.every((row) => row.every((cell) => cell !== ''));
+}
+
+function highlightWinningCells(cells) {
+  cells.forEach(([row, col]) => {
+    const cellButton = boardElement.querySelector(`[data-cell="${row}-${col}"]`);
+    if (cellButton) {
+      cellButton.classList.add('cell--winning');
+    }
+  });
+}
+
+function handleCellClick(event) {
+  const cell = event.currentTarget;
+  if (gameOver || cell.textContent !== '') {
+    return;
+  }
+
+  const [row, col] = getCellCoordinates(cell);
+  boardState[row][col] = currentPlayer;
+  cell.textContent = currentPlayer;
+  cell.disabled = true;
+
+  const winningCells = checkWin(currentPlayer);
+  if (winningCells) {
+    highlightWinningCells(winningCells);
+    messageElement.textContent = `${currentPlayer} wins!`;
+    gameOver = true;
+    return;
+  }
+
+  if (checkDraw()) {
+    messageElement.textContent = "It's a draw!";
+    gameOver = true;
+    return;
+  }
+
+  currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+  messageElement.textContent = `${currentPlayer}'s turn`;
+}
+
+function setupBoard() {
+  const cells = boardElement.querySelectorAll('[data-cell]');
+  cells.forEach((cell) => {
+    cell.addEventListener('click', handleCellClick);
+  });
+}
+
+if (settingsForm) {
+  settingsForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    resetGame({ startingPlayer: startingPlayerSelect.value });
+    if (settingsModal) {
+      settingsModal.close();
+    }
+  });
+}
+
+const resetButton = document.getElementById('reset-button');
+if (resetButton) {
+  resetButton.addEventListener('click', () => {
+    resetGame({ startingPlayer: startingPlayerSelect.value });
+  });
+}
+
+resetGame({ startingPlayer: currentPlayer });
+setupBoard();

--- a/site/js/ui/modal.js
+++ b/site/js/ui/modal.js
@@ -1,0 +1,213 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([type="hidden"]):not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter((element) => {
+    if (element.hasAttribute('hidden')) {
+      return false;
+    }
+
+    if (element.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+
+    const { width, height } = element.getBoundingClientRect();
+    return width > 0 || height > 0;
+  });
+}
+
+export class Modal {
+  constructor(root) {
+    if (!root) {
+      throw new Error('A modal root element is required.');
+    }
+
+    this.root = root;
+    this.dialog = root.querySelector('[data-modal-dialog]') || root;
+    this.overlay = root.querySelector('[data-modal-overlay]');
+    this.closeButtons = Array.from(root.querySelectorAll('[data-modal-close]'));
+    this.isOpen = false;
+    this.lastFocusedElement = null;
+    this.focusableElements = [];
+
+    this.handleKeydown = this.handleKeydown.bind(this);
+    this.handleFocusIn = this.handleFocusIn.bind(this);
+    this.handleTriggerClick = this.handleTriggerClick.bind(this);
+
+    this.setupAccessibility();
+    this.attachStaticListeners();
+  }
+
+  setupAccessibility() {
+    if (!this.dialog.hasAttribute('role')) {
+      this.dialog.setAttribute('role', 'dialog');
+    }
+
+    if (!this.dialog.hasAttribute('aria-modal')) {
+      this.dialog.setAttribute('aria-modal', 'true');
+    }
+
+    if (!this.dialog.hasAttribute('tabindex')) {
+      this.dialog.setAttribute('tabindex', '-1');
+    }
+
+    this.root.setAttribute('aria-hidden', 'true');
+  }
+
+  attachStaticListeners() {
+    this.closeButtons.forEach((button) => {
+      button.addEventListener('click', () => this.close());
+    });
+
+    if (this.overlay) {
+      this.overlay.addEventListener('click', () => this.close());
+    }
+  }
+
+  registerTrigger(trigger) {
+    trigger.addEventListener('click', this.handleTriggerClick);
+  }
+
+  handleTriggerClick(event) {
+    event.preventDefault();
+    const trigger = event.currentTarget;
+    this.open(trigger);
+  }
+
+  open(trigger = null) {
+    if (this.isOpen) {
+      return;
+    }
+
+    this.isOpen = true;
+    this.lastFocusedElement = trigger || document.activeElement;
+    this.root.classList.add('modal--visible');
+    this.root.setAttribute('aria-hidden', 'false');
+
+    this.focusableElements = getFocusableElements(this.dialog);
+    document.addEventListener('keydown', this.handleKeydown, true);
+    document.addEventListener('focusin', this.handleFocusIn, true);
+
+    requestAnimationFrame(() => {
+      const elementToFocus = this.focusableElements[0] || this.dialog;
+      if (elementToFocus && typeof elementToFocus.focus === 'function') {
+        elementToFocus.focus({ preventScroll: true });
+      }
+    });
+  }
+
+  close() {
+    if (!this.isOpen) {
+      return;
+    }
+
+    this.isOpen = false;
+    this.root.classList.remove('modal--visible');
+    this.root.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('keydown', this.handleKeydown, true);
+    document.removeEventListener('focusin', this.handleFocusIn, true);
+
+    if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+      this.lastFocusedElement.focus({ preventScroll: true });
+    }
+
+    this.lastFocusedElement = null;
+  }
+
+  handleKeydown(event) {
+    if (!this.isOpen) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    this.focusableElements = getFocusableElements(this.dialog);
+    if (this.focusableElements.length === 0) {
+      event.preventDefault();
+      this.dialog.focus({ preventScroll: true });
+      return;
+    }
+
+    const { activeElement } = document;
+    const firstElement = this.focusableElements[0];
+    const lastElement = this.focusableElements[this.focusableElements.length - 1];
+
+    if (event.shiftKey) {
+      if (activeElement === firstElement || !this.dialog.contains(activeElement)) {
+        event.preventDefault();
+        if (lastElement && typeof lastElement.focus === 'function') {
+          lastElement.focus({ preventScroll: true });
+        }
+      }
+    } else if (activeElement === lastElement) {
+      event.preventDefault();
+      if (firstElement && typeof firstElement.focus === 'function') {
+        firstElement.focus({ preventScroll: true });
+      }
+    }
+  }
+
+  handleFocusIn(event) {
+    if (!this.isOpen) {
+      return;
+    }
+
+    if (!this.root.contains(event.target)) {
+      const fallback = this.focusableElements[0] || this.dialog;
+      if (fallback && typeof fallback.focus === 'function') {
+        fallback.focus({ preventScroll: true });
+      }
+    }
+  }
+}
+
+export function initModals(selector = '[data-modal]') {
+  const modalElements = Array.from(document.querySelectorAll(selector));
+  const modals = new Map();
+
+  modalElements.forEach((element) => {
+    const modal = new Modal(element);
+    modals.set(element.id || element, modal);
+  });
+
+  const triggers = Array.from(document.querySelectorAll('[data-modal-trigger]'));
+  triggers.forEach((trigger) => {
+    const targetId = trigger.getAttribute('data-modal-trigger');
+    if (!targetId) {
+      return;
+    }
+
+    const modalElement = document.getElementById(targetId);
+    if (!modalElement) {
+      return;
+    }
+
+    const modalInstance = modals.get(modalElement.id);
+    if (modalInstance) {
+      modalInstance.registerTrigger(trigger);
+      trigger.setAttribute('aria-haspopup', 'dialog');
+      trigger.setAttribute('aria-controls', modalElement.id);
+    }
+  });
+
+  return modals;
+}


### PR DESCRIPTION
## Summary
- implement a reusable modal controller with focus trapping, escape-to-close support, and trigger focus restoration
- add modal presentation styles and reorganize the layout to house settings controls inside the modal dialog
- refresh the game markup/logic to use buttons for cells, handle resets from settings, and keep the UI state in sync

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68df2b4173b08328860976bf8fe3a711