### PR TITLE
Add accessible tooltips and help overlay for Tic Tac Toe

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,119 +1,536 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="site/css/tooltip.css">
   <style>
+    :root {
+      color-scheme: light dark;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
+      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 2rem 1.5rem 3rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      background: #f2f5f9;
+      color: #1d1d1f;
+      min-height: 100vh;
     }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
+
+    body.has-overlay {
+      overflow: hidden;
     }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2rem, 5vw, 2.75rem);
+      letter-spacing: 0.02em;
+    }
+
+    main {
+      width: min(90vw, 30rem);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    .controls {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .control-button {
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      background: linear-gradient(180deg, #ffffff, #e9edf2);
+      color: inherit;
+      font-size: 1rem;
+      font-weight: 600;
       cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
     }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
+
+    .control-button:hover,
+    .control-button:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.2);
+      outline: none;
     }
-    
+
+    .board {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(5rem, 1fr));
+      width: min(90vw, 22rem);
+      aspect-ratio: 1 / 1;
+      background: #0f172a;
+      border-radius: 1rem;
+      padding: 0.75rem;
+      gap: 0.75rem;
+      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.08), 0 1rem 2.5rem rgba(15, 23, 42, 0.35);
+    }
+
+    .cell {
+      border: none;
+      border-radius: 0.75rem;
+      background: rgba(241, 245, 249, 0.92);
+      color: #0f172a;
+      font-size: clamp(2.5rem, 10vw, 3.25rem);
+      font-weight: 700;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .cell:hover,
+    .cell:focus-visible {
+      background: #ffffff;
+      transform: translateY(-2px);
+      box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.2);
+      outline: none;
+    }
+
+    .cell:disabled {
+      cursor: not-allowed;
+      opacity: 0.75;
+      box-shadow: none;
+      transform: none;
+    }
+
     .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
+      min-height: 1.5rem;
+      font-size: 1.125rem;
+      font-weight: 600;
+      text-align: center;
+    }
+
+    [hidden] {
+      display: none !important;
+    }
+
+    .help-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.72);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 900;
+    }
+
+    .help-overlay__dialog {
+      position: relative;
+      width: min(90vw, 32rem);
+      max-height: min(85vh, 36rem);
+      overflow: auto;
+      background: #ffffff;
+      color: #111827;
+      border-radius: 1rem;
+      padding: clamp(1.25rem, 4vw, 2rem);
+      box-shadow: 0 1.25rem 3rem rgba(15, 23, 42, 0.4);
+    }
+
+    .help-overlay__dialog:focus-visible {
+      outline: 3px solid #6366f1;
+      outline-offset: 6px;
+    }
+
+    .help-overlay__close {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      border: none;
+      background: transparent;
+      font-size: 1.5rem;
+      line-height: 1;
+      cursor: pointer;
+      padding: 0.25rem;
+      border-radius: 0.5rem;
+    }
+
+    .help-overlay__close:hover,
+    .help-overlay__close:focus-visible {
+      background: rgba(99, 102, 241, 0.1);
+      outline: none;
+    }
+
+    .help-overlay__dialog h2 {
+      margin-top: 0;
+      font-size: 1.75rem;
+    }
+
+    .help-overlay__dialog h3 {
+      margin-bottom: 0.35rem;
+      margin-top: 1.25rem;
+      font-size: 1.1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #475569;
+    }
+
+    .help-overlay__dialog ul {
+      padding-left: 1.2rem;
+      margin: 0.25rem 0 0;
+      line-height: 1.5;
+    }
+
+    .help-overlay__dialog p {
+      margin: 0 0 0.75rem;
+      line-height: 1.6;
+    }
+
+    .help-overlay__dismiss {
+      margin-top: 1.5rem;
+      padding: 0.6rem 1.25rem;
+      border-radius: 0.75rem;
+      border: none;
+      background: linear-gradient(180deg, #4f46e5, #4338ca);
+      color: #ffffff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .help-overlay__dismiss:hover,
+    .help-overlay__dismiss:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 0.75rem 1.25rem rgba(79, 70, 229, 0.35);
+      outline: none;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #f8fafc;
+      }
+
+      .control-button {
+        background: linear-gradient(180deg, #1f2937, #111827);
+        color: #f8fafc;
+        border-color: rgba(148, 163, 184, 0.35);
+      }
+
+      .board {
+        background: #020617;
+        box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.08), 0 1rem 2.5rem rgba(2, 6, 23, 0.65);
+      }
+
+      .cell {
+        background: rgba(15, 23, 42, 0.92);
+        color: #f8fafc;
+      }
+
+      .cell:hover,
+      .cell:focus-visible {
+        background: rgba(30, 41, 59, 0.95);
+        box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.6);
+      }
+
+      .message {
+        color: #e2e8f0;
+      }
+
+      .help-overlay {
+        background: rgba(2, 6, 23, 0.72);
+      }
+
+      .help-overlay__dialog {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      .help-overlay__close:hover,
+      .help-overlay__close:focus-visible {
+        background: rgba(99, 102, 241, 0.25);
+      }
+    }
+
+    @media (max-width: 32rem) {
+      body {
+        padding: 1.5rem 1rem 2rem;
+      }
+
+      .board {
+        padding: 0.5rem;
+        gap: 0.5rem;
+      }
     }
   </style>
+  <script src="site/js/ui/tooltip.js" defer></script>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <main>
+    <h1>Tic Tac Toe</h1>
+    <div class="controls">
+      <button id="help-button" type="button" class="control-button" data-tooltip="Learn how to play and use the controls.">
+        Help
+      </button>
+      <button id="reset-button" type="button" class="control-button" data-tooltip="Start a new round with an empty board.">
+        Reset Game
+      </button>
+    </div>
+    <div class="board" role="grid" aria-label="Tic Tac Toe board">
+      <button type="button" class="cell" data-row="0" data-col="0" aria-label="Row 1, column 1"></button>
+      <button type="button" class="cell" data-row="0" data-col="1" aria-label="Row 1, column 2"></button>
+      <button type="button" class="cell" data-row="0" data-col="2" aria-label="Row 1, column 3"></button>
+      <button type="button" class="cell" data-row="1" data-col="0" aria-label="Row 2, column 1"></button>
+      <button type="button" class="cell" data-row="1" data-col="1" aria-label="Row 2, column 2"></button>
+      <button type="button" class="cell" data-row="1" data-col="2" aria-label="Row 2, column 3"></button>
+      <button type="button" class="cell" data-row="2" data-col="0" aria-label="Row 3, column 1"></button>
+      <button type="button" class="cell" data-row="2" data-col="1" aria-label="Row 3, column 2"></button>
+      <button type="button" class="cell" data-row="2" data-col="2" aria-label="Row 3, column 3"></button>
+    </div>
+    <p class="message" role="status" aria-live="polite"></p>
+  </main>
+
+  <div id="help-overlay" class="help-overlay" hidden>
+    <div class="help-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="help-overlay-title" tabindex="-1">
+      <button type="button" class="help-overlay__close" aria-label="Close help" data-action="close-help">&times;</button>
+      <h2 id="help-overlay-title">How to Play</h2>
+      <p>
+        Tic Tac Toe is a simple strategy game for two players. Take turns placing your mark on the board and try to be the first to align three of your marks.
+      </p>
+      <h3>Rules</h3>
+      <ul>
+        <li>Player X always goes first, followed by Player O.</li>
+        <li>Marks can be placed on any empty square.</li>
+        <li>Create a straight line of three of your marks horizontally, vertically, or diagonally to win.</li>
+        <li>If the board fills up with no winner, the game ends in a draw.</li>
+      </ul>
+      <h3>Controls</h3>
+      <ul>
+        <li>Select a square with your mouse, or focus it with Tab/Shift+Tab and press Enter or Space to place your mark.</li>
+        <li>Use the Reset Game button whenever you want to start a fresh round.</li>
+        <li>Press the Escape key or choose a close button to dismiss this help panel.</li>
+      </ul>
+      <button type="button" class="help-overlay__dismiss" data-action="close-help">Back to the game</button>
+    </div>
+  </div>
 
   <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
+    (function () {
+      'use strict';
+
+      const boardState = [
+        ['', '', ''],
+        ['', '', ''],
+        ['', '', '']
+      ];
+      const cells = Array.from(document.querySelectorAll('.cell'));
+      const messageEl = document.querySelector('.message');
+      const helpButton = document.getElementById('help-button');
+      const resetButton = document.getElementById('reset-button');
+      const overlay = document.getElementById('help-overlay');
+      const overlayDialog = overlay.querySelector('.help-overlay__dialog');
+      const overlayDismissButtons = overlay.querySelectorAll('[data-action="close-help"]');
+      const focusableSelector = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+      let currentPlayer = 'X';
+      let gameOver = false;
+      let previousFocus = null;
+
+      const initialLabels = cells.map((cell) => cell.getAttribute('aria-label'));
+
+      function updateMessage(content) {
+        messageEl.textContent = content;
       }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+
+      function announceTurn() {
+        updateMessage(`Player ${currentPlayer}'s turn.`);
       }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
+
+      function resetBoardState() {
+        for (let row = 0; row < 3; row += 1) {
+          for (let col = 0; col < 3; col += 1) {
+            boardState[row][col] = '';
           }
         }
       }
-      
-      return true;
-    }
+
+      function resetCells() {
+        cells.forEach((cell, index) => {
+          cell.textContent = '';
+          cell.disabled = false;
+          cell.setAttribute('aria-label', initialLabels[index]);
+        });
+      }
+
+      function checkWin(player) {
+        for (let i = 0; i < 3; i += 1) {
+          if (boardState[i][0] === player && boardState[i][1] === player && boardState[i][2] === player) {
+            return true;
+          }
+          if (boardState[0][i] === player && boardState[1][i] === player && boardState[2][i] === player) {
+            return true;
+          }
+        }
+
+        if (boardState[0][0] === player && boardState[1][1] === player && boardState[2][2] === player) {
+          return true;
+        }
+        if (boardState[0][2] === player && boardState[1][1] === player && boardState[2][0] === player) {
+          return true;
+        }
+
+        return false;
+      }
+
+      function checkDraw() {
+        return boardState.every((row) => row.every((cell) => cell !== ''));
+      }
+
+      function completeGame(resultText) {
+        updateMessage(resultText);
+        gameOver = true;
+        cells.forEach((cell) => {
+          cell.disabled = true;
+        });
+      }
+
+      function markCell(cell, row, col) {
+        boardState[row][col] = currentPlayer;
+        cell.textContent = currentPlayer;
+        cell.disabled = true;
+        cell.setAttribute('aria-label', `Row ${row + 1}, column ${col + 1}, marked ${currentPlayer}`);
+      }
+
+      function handleMove(event) {
+        const cell = event.currentTarget;
+        const row = Number(cell.dataset.row);
+        const col = Number(cell.dataset.col);
+
+        if (gameOver || boardState[row][col] !== '') {
+          return;
+        }
+
+        markCell(cell, row, col);
+
+        if (checkWin(currentPlayer)) {
+          completeGame(`Player ${currentPlayer} wins!`);
+          return;
+        }
+
+        if (checkDraw()) {
+          completeGame('The game is a draw.');
+          return;
+        }
+
+        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+        announceTurn();
+      }
+
+      function handleCellKeydown(event) {
+        if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+          event.preventDefault();
+          handleMove(event);
+        }
+      }
+
+      function resetGame() {
+        resetBoardState();
+        resetCells();
+        currentPlayer = 'X';
+        gameOver = false;
+        announceTurn();
+      }
+
+      function openHelp() {
+        if (!overlay.hasAttribute('hidden')) {
+          return;
+        }
+        previousFocus = document.activeElement;
+        overlay.removeAttribute('hidden');
+        document.body.classList.add('has-overlay');
+        window.setTimeout(() => {
+          const focusTarget = overlay.querySelector('[data-action="close-help"]');
+          if (focusTarget) {
+            focusTarget.focus();
+          } else {
+            overlayDialog.focus();
+          }
+        }, 0);
+      }
+
+      function closeHelp() {
+        if (overlay.hasAttribute('hidden')) {
+          return;
+        }
+        overlay.setAttribute('hidden', '');
+        document.body.classList.remove('has-overlay');
+        if (previousFocus) {
+          previousFocus.focus();
+        }
+      }
+
+      function trapFocus(event) {
+        if (event.key !== 'Tab') {
+          return;
+        }
+
+        const focusable = Array.from(overlay.querySelectorAll(focusableSelector)).filter((el) => !el.hasAttribute('disabled'));
+        if (focusable.length === 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+
+      cells.forEach((cell) => {
+        cell.addEventListener('click', handleMove);
+        cell.addEventListener('keydown', handleCellKeydown);
+      });
+
+      resetButton.addEventListener('click', resetGame);
+      helpButton.addEventListener('click', openHelp);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeHelp();
+        }
+      });
+
+      overlay.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+          closeHelp();
+          return;
+        }
+        trapFocus(event);
+      });
+
+      overlayDismissButtons.forEach((button) => {
+        button.addEventListener('click', closeHelp);
+      });
+
+      resetGame();
+    })();
   </script>
 </body>
 </html>

--- a/site/css/tooltip.css
+++ b/site/css/tooltip.css
@@ -1,0 +1,51 @@
+.tooltip {
+  position: absolute;
+  z-index: 1000;
+  max-width: 18rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background-color: #2f2f2f;
+  color: #f8f8f8;
+  font-size: 0.875rem;
+  line-height: 1.3;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(0, -4px, 0);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.tooltip[data-visible="true"] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.tooltip::after {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+.tooltip[data-placement="top"]::after {
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-color: #2f2f2f transparent transparent transparent;
+}
+
+.tooltip[data-placement="bottom"]::after {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent #2f2f2f transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none;
+  }
+}

--- a/site/js/ui/tooltip.js
+++ b/site/js/ui/tooltip.js
@@ -1,0 +1,138 @@
+(function () {
+  'use strict';
+
+  const TOOLTIP_ATTRIBUTE = 'data-tooltip';
+  const ACTIVE_ATTRIBUTE = 'data-visible';
+  const PLACEMENT_ATTRIBUTE = 'data-placement';
+
+  function uniqueIdGenerator() {
+    let counter = 0;
+    return function nextId() {
+      counter += 1;
+      return `tooltip-${counter}`;
+    };
+  }
+
+  const nextTooltipId = uniqueIdGenerator();
+
+  function setupTooltip(trigger) {
+    const tooltipText = trigger.getAttribute(TOOLTIP_ATTRIBUTE);
+    if (!tooltipText) {
+      return;
+    }
+
+    const tooltip = document.createElement('div');
+    tooltip.className = 'tooltip';
+    tooltip.setAttribute('role', 'tooltip');
+    tooltip.id = trigger.getAttribute('aria-describedby') || nextTooltipId();
+    tooltip.textContent = tooltipText;
+    tooltip.hidden = true;
+    tooltip.setAttribute(ACTIVE_ATTRIBUTE, 'false');
+    tooltip.setAttribute(PLACEMENT_ATTRIBUTE, 'top');
+
+    document.body.appendChild(tooltip);
+
+    if (!trigger.hasAttribute('aria-describedby')) {
+      trigger.setAttribute('aria-describedby', tooltip.id);
+    }
+
+    const showTooltip = () => {
+      tooltip.hidden = false;
+      tooltip.setAttribute(ACTIVE_ATTRIBUTE, 'true');
+      positionTooltip(trigger, tooltip);
+    };
+
+    const hideTooltip = () => {
+      tooltip.setAttribute(ACTIVE_ATTRIBUTE, 'false');
+      window.setTimeout(() => {
+        if (tooltip.getAttribute(ACTIVE_ATTRIBUTE) === 'false') {
+          tooltip.hidden = true;
+        }
+      }, 150);
+    };
+
+    const handleMouseEnter = () => {
+      showTooltip();
+    };
+
+    const handleMouseLeave = () => {
+      hideTooltip();
+    };
+
+    const handleFocus = () => {
+      showTooltip();
+    };
+
+    const handleBlur = () => {
+      hideTooltip();
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        hideTooltip();
+      }
+    };
+
+    trigger.addEventListener('mouseenter', handleMouseEnter);
+    trigger.addEventListener('mouseleave', handleMouseLeave);
+    trigger.addEventListener('focus', handleFocus);
+    trigger.addEventListener('blur', handleBlur);
+    trigger.addEventListener('keydown', handleKeyDown);
+
+    window.addEventListener('scroll', hideTooltip, { passive: true });
+    window.addEventListener('resize', () => {
+      if (tooltip.getAttribute(ACTIVE_ATTRIBUTE) === 'true') {
+        positionTooltip(trigger, tooltip);
+      }
+    });
+  }
+
+  function positionTooltip(trigger, tooltip) {
+    const triggerRect = trigger.getBoundingClientRect();
+    tooltip.style.left = '0px';
+    tooltip.style.top = '0px';
+
+    // Force layout to ensure measurements are up-to-date.
+    const tooltipRect = tooltip.getBoundingClientRect();
+
+    const preferredTop = triggerRect.top + window.scrollY - tooltipRect.height - 8;
+    const spaceAbove = triggerRect.top;
+    const spaceBelow = window.innerHeight - triggerRect.bottom;
+
+    let top;
+    let placement;
+    if (preferredTop >= 0 || spaceAbove > spaceBelow) {
+      top = Math.max(window.scrollY + 4, preferredTop);
+      placement = 'top';
+    } else {
+      top = triggerRect.bottom + window.scrollY + 8;
+      placement = 'bottom';
+    }
+
+    let left = triggerRect.left + window.scrollX + (triggerRect.width - tooltipRect.width) / 2;
+    const minLeft = window.scrollX + 4;
+    const maxLeft = window.scrollX + document.documentElement.clientWidth - tooltipRect.width - 4;
+    if (left < minLeft) {
+      left = minLeft;
+    } else if (left > maxLeft) {
+      left = maxLeft;
+    }
+
+    tooltip.setAttribute(PLACEMENT_ATTRIBUTE, placement);
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+  }
+
+  function initTooltips() {
+    const triggers = document.querySelectorAll(`[${TOOLTIP_ATTRIBUTE}]`);
+    triggers.forEach((trigger) => {
+      setupTooltip(trigger);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTooltips);
+  } else {
+    initTooltips();
+  }
+})();


### PR DESCRIPTION
## Summary
- replace the board UI with focusable buttons and add reset/help controls
- implement a keyboard-accessible help overlay that explains the rules and controls
- add reusable tooltip styling and logic for focus/hover hints

## Testing
- manual verification

------
https://chatgpt.com/codex/tasks/task_e_68df2b43aecc8328a24b023b69ce606d