### PR TITLE
Add light/dark theme toggle for Tic Tac Toe UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,59 +1,122 @@
-
-
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="site/css/theme.css">
   <style>
     body {
+      background-color: var(--background-color);
+      color: var(--text-color);
       font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 40px 20px;
+      transition: background-color 0.3s ease, color 0.3s ease;
     }
+
+    .site-header {
+      width: 100%;
+      max-width: 420px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 40px;
+    }
+
+    .site-title {
+      font-size: 32px;
+      margin: 0;
+    }
+
+    .theme-toggle {
+      border: 1px solid var(--toggle-border-color);
+      background-color: var(--toggle-background-color);
+      color: var(--toggle-text-color);
+      border-radius: 999px;
+      padding: 8px 16px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+    }
+
+    .theme-toggle:hover {
+      transform: translateY(-1px);
+    }
+
+    .theme-toggle:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: 2px;
+    }
+
+    .site-main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+      width: 100%;
+    }
+
     .board {
       display: inline-block;
       border-collapse: collapse;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
     }
+
     .board td {
       width: 100px;
       height: 100px;
-      border: 2px solid #ccc;
+      border: 2px solid var(--board-border-color);
       font-size: 48px;
       text-align: center;
       vertical-align: middle;
       cursor: pointer;
+      transition: background-color 0.2s ease;
+      color: var(--text-color);
     }
-    
+
     .board td:hover {
-      background-color: #f2f2f2;
+      background-color: var(--cell-hover-bg);
     }
-    
+
     .message {
-      margin-top: 20px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 1.5em;
     }
   </style>
+  <script defer src="site/js/ui/theme.js"></script>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <header class="site-header">
+    <h1 class="site-title">Tic Tac Toe</h1>
+    <button type="button" class="theme-toggle" data-role="theme-toggle" aria-pressed="false">
+      <span class="theme-toggle__label">Switch to dark theme</span>
+    </button>
+  </header>
+  <main class="site-main">
+    <table class="board">
+      <tr>
+        <td onclick="makeMove(0, 0)"></td>
+        <td onclick="makeMove(0, 1)"></td>
+        <td onclick="makeMove(0, 2)"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(1, 0)"></td>
+        <td onclick="makeMove(1, 1)"></td>
+        <td onclick="makeMove(1, 2)"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(2, 0)"></td>
+        <td onclick="makeMove(2, 1)"></td>
+        <td onclick="makeMove(2, 2)"></td>
+      </tr>
+    </table>
+    <div class="message"></div>
+  </main>
 
   <script>
     var currentPlayer = 'X';
@@ -63,26 +126,26 @@
       ['', '', '']
     ];
     var gameOver = false;
-    
+
     function makeMove(row, col) {
       if (gameOver || board[row][col] !== '') {
         return;
       }
-      
+
       board[row][col] = currentPlayer;
       document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
+
       if (checkWin(currentPlayer)) {
         document.querySelector('.message').textContent = currentPlayer + ' Wins!';
         gameOver = true;
       } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
+        document.querySelector('.message').textContent = 'It\'s a draw!';
         gameOver = true;
       } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
       }
     }
-    
+
     function checkWin(player) {
       for (var i = 0; i < 3; i++) {
         if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
@@ -92,17 +155,17 @@
           return true; // Vertical
         }
       }
-      
+
       if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
         return true; // Diagonal
       }
       if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
         return true; // Diagonal
       }
-      
+
       return false;
     }
-    
+
     function checkDraw() {
       for (var i = 0; i < 3; i++) {
         for (var j = 0; j < 3; j++) {
@@ -111,7 +174,7 @@
           }
         }
       }
-      
+
       return true;
     }
   </script>

--- a/site/css/theme.css
+++ b/site/css/theme.css
@@ -1,0 +1,49 @@
+:root {
+  color-scheme: light;
+  --background-color: #ffffff;
+  --text-color: #111827;
+  --board-border-color: #d1d5db;
+  --cell-hover-bg: #f3f4f6;
+  --toggle-background-color: #f9fafb;
+  --toggle-text-color: #111827;
+  --toggle-border-color: #d1d5db;
+  --accent-color: #2563eb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --background-color: #0f172a;
+    --text-color: #f8fafc;
+    --board-border-color: #334155;
+    --cell-hover-bg: #1e293b;
+    --toggle-background-color: #1e293b;
+    --toggle-text-color: #f8fafc;
+    --toggle-border-color: #475569;
+    --accent-color: #60a5fa;
+  }
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --background-color: #ffffff;
+  --text-color: #111827;
+  --board-border-color: #d1d5db;
+  --cell-hover-bg: #f3f4f6;
+  --toggle-background-color: #f9fafb;
+  --toggle-text-color: #111827;
+  --toggle-border-color: #d1d5db;
+  --accent-color: #2563eb;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --background-color: #0f172a;
+  --text-color: #f8fafc;
+  --board-border-color: #334155;
+  --cell-hover-bg: #1e293b;
+  --toggle-background-color: #1e293b;
+  --toggle-text-color: #f8fafc;
+  --toggle-border-color: #475569;
+  --accent-color: #60a5fa;
+}

--- a/site/js/ui/theme.js
+++ b/site/js/ui/theme.js
@@ -1,0 +1,91 @@
+(function () {
+  var storageKey = 'theme';
+  var root = document.documentElement;
+  var toggle = document.querySelector('[data-role="theme-toggle"]');
+  if (!toggle) {
+    return;
+  }
+
+  var prefersDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem(storageKey);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setStoredTheme(theme) {
+    try {
+      localStorage.setItem(storageKey, theme);
+    } catch (error) {
+      // Ignore write errors (e.g., private browsing restrictions)
+    }
+  }
+
+  function updateToggleLabel(activeTheme) {
+    var labelText = activeTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme';
+    var label = toggle.querySelector('.theme-toggle__label');
+    if (label) {
+      label.textContent = labelText;
+    } else {
+      toggle.textContent = labelText;
+    }
+    toggle.setAttribute('title', labelText);
+  }
+
+  function applyTheme(theme, options) {
+    var persist = options && options.persist !== undefined ? options.persist : true;
+    if (theme === 'dark' || theme === 'light') {
+      root.setAttribute('data-theme', theme);
+      if (persist) {
+        setStoredTheme(theme);
+      }
+    }
+
+    var activeTheme = theme;
+    if (activeTheme !== 'dark' && activeTheme !== 'light') {
+      activeTheme = prefersDarkQuery.matches ? 'dark' : 'light';
+    }
+
+    toggle.setAttribute('aria-pressed', activeTheme === 'dark');
+    updateToggleLabel(activeTheme);
+  }
+
+  function initializeTheme() {
+    var storedTheme = getStoredTheme();
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      applyTheme(storedTheme, { persist: false });
+    } else {
+      applyTheme(prefersDarkQuery.matches ? 'dark' : 'light', { persist: false });
+    }
+  }
+
+  toggle.addEventListener('click', function () {
+    var currentTheme = root.getAttribute('data-theme');
+    if (currentTheme !== 'dark' && currentTheme !== 'light') {
+      currentTheme = prefersDarkQuery.matches ? 'dark' : 'light';
+    }
+
+    var nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme, { persist: true });
+  });
+
+  function handlePreferenceChange(event) {
+    var storedTheme = getStoredTheme();
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      return;
+    }
+
+    applyTheme(event.matches ? 'dark' : 'light', { persist: false });
+  }
+
+  if (typeof prefersDarkQuery.addEventListener === 'function') {
+    prefersDarkQuery.addEventListener('change', handlePreferenceChange);
+  } else if (typeof prefersDarkQuery.addListener === 'function') {
+    prefersDarkQuery.addListener(handlePreferenceChange);
+  }
+
+  initializeTheme();
+})();


### PR DESCRIPTION
## Summary
- add CSS variables that define coordinated light and dark themes with system preference support
- implement a theme toggle controller that persists the user selection in localStorage
- refresh the HTML layout with a header and toggle control that uses the shared theme styles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df2b41ebf48328aee99c9802020a25