### PR TITLE
Add shareable state link support to Tic Tac Toe

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -8,7 +6,10 @@
     body {
       font-family: Arial, sans-serif;
       text-align: center;
-      margin-top: 100px;
+      margin-top: 60px;
+    }
+    .container {
+      display: inline-block;
     }
     .board {
       display: inline-block;
@@ -22,67 +23,201 @@
       text-align: center;
       vertical-align: middle;
       cursor: pointer;
+      transition: background-color 0.2s ease-in-out;
     }
-    
+
     .board td:hover {
       background-color: #f2f2f2;
     }
-    
+
     .message {
       margin-top: 20px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 32px;
+    }
+
+    .scoreboard {
+      margin-top: 20px;
+      font-size: 18px;
+      text-align: left;
+    }
+
+    .scoreboard div {
+      margin: 4px 0;
+    }
+
+    .controls {
+      margin-top: 20px;
+    }
+
+    .controls button {
+      margin: 0 8px;
+      padding: 10px 16px;
+      font-size: 16px;
+      cursor: pointer;
+    }
+
+    .share-status {
+      margin-top: 12px;
+      min-height: 20px;
+      color: #2b6cb0;
+      font-size: 16px;
+    }
+
+    .share-status.error {
+      color: #c53030;
     }
   </style>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <div class="container">
+    <table class="board">
+      <tr>
+        <td onclick="makeMove(0, 0)"></td>
+        <td onclick="makeMove(0, 1)"></td>
+        <td onclick="makeMove(0, 2)"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(1, 0)"></td>
+        <td onclick="makeMove(1, 1)"></td>
+        <td onclick="makeMove(1, 2)"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(2, 0)"></td>
+        <td onclick="makeMove(2, 1)"></td>
+        <td onclick="makeMove(2, 2)"></td>
+      </tr>
+    </table>
+    <div class="message"></div>
+    <div class="scoreboard">
+      <div>Player X Wins: <span id="score-x">0</span></div>
+      <div>Player O Wins: <span id="score-o">0</span></div>
+      <div>Draws: <span id="score-draws">0</span></div>
+    </div>
+    <div class="controls">
+      <button id="reset-button">Reset Board</button>
+      <button id="copy-link-button">Copy Shareable Link</button>
+    </div>
+    <div class="share-status" id="share-status"></div>
+  </div>
 
+  <script src="site/js/share/stateLink.js"></script>
   <script>
     var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
+    var board = StateLink.createEmptyBoard();
+    var scores = { X: 0, O: 0, draws: 0 };
     var gameOver = false;
-    
+
+    var boardElement = document.querySelector('.board');
+    var messageElement = document.querySelector('.message');
+    var scoreElements = {
+      X: document.getElementById('score-x'),
+      O: document.getElementById('score-o'),
+      draws: document.getElementById('score-draws')
+    };
+    var shareStatusElement = document.getElementById('share-status');
+    var resetButton = document.getElementById('reset-button');
+    var copyLinkButton = document.getElementById('copy-link-button');
+
+    function updateBoardUI() {
+      for (var i = 0; i < 3; i++) {
+        for (var j = 0; j < 3; j++) {
+          boardElement.rows[i].cells[j].textContent = board[i][j];
+        }
+      }
+    }
+
+    function updateScoreboard() {
+      scoreElements.X.textContent = scores.X;
+      scoreElements.O.textContent = scores.O;
+      scoreElements.draws.textContent = scores.draws;
+    }
+
+    function updateGameMessage() {
+      var winner = null;
+      if (checkWin('X')) {
+        winner = 'X';
+      } else if (checkWin('O')) {
+        winner = 'O';
+      }
+
+      if (winner) {
+        messageElement.textContent = winner + ' Wins!';
+        gameOver = true;
+        return;
+      }
+
+      if (checkDraw()) {
+        messageElement.textContent = "It's a draw!";
+        gameOver = true;
+        return;
+      }
+
+      gameOver = false;
+      messageElement.textContent = currentPlayer + "'s turn";
+    }
+
+    function clearShareStatus() {
+      shareStatusElement.textContent = '';
+      shareStatusElement.classList.remove('error');
+    }
+
     function makeMove(row, col) {
+      clearShareStatus();
       if (gameOver || board[row][col] !== '') {
         return;
       }
-      
+
       board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
+      boardElement.rows[row].cells[col].textContent = currentPlayer;
+
       if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
+        messageElement.textContent = currentPlayer + ' Wins!';
+        scores[currentPlayer] += 1;
+        updateScoreboard();
         gameOver = true;
       } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
+        messageElement.textContent = "It's a draw!";
+        scores.draws += 1;
+        updateScoreboard();
         gameOver = true;
       } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+        messageElement.textContent = currentPlayer + "'s turn";
       }
     }
-    
+
+    function resetBoard() {
+      board = StateLink.createEmptyBoard();
+      currentPlayer = 'X';
+      gameOver = false;
+      updateBoardUI();
+      updateGameMessage();
+      clearShareStatus();
+    }
+
+    function handleCopyLink() {
+      clearShareStatus();
+      StateLink.copyStateLink({
+        board: board,
+        currentPlayer: currentPlayer,
+        scores: scores
+      })
+        .then(function () {
+          shareStatusElement.textContent = 'Shareable link copied to clipboard!';
+        })
+        .catch(function (err) {
+          shareStatusElement.textContent = 'Unable to copy automatically. Copy this link: ' + StateLink.buildShareUrl({
+            board: board,
+            currentPlayer: currentPlayer,
+            scores: scores
+          });
+          shareStatusElement.classList.add('error');
+          console.error(err);
+        });
+    }
+
     function checkWin(player) {
       for (var i = 0; i < 3; i++) {
         if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
@@ -92,17 +227,17 @@
           return true; // Vertical
         }
       }
-      
+
       if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
         return true; // Diagonal
       }
       if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
         return true; // Diagonal
       }
-      
+
       return false;
     }
-    
+
     function checkDraw() {
       for (var i = 0; i < 3; i++) {
         for (var j = 0; j < 3; j++) {
@@ -111,9 +246,44 @@
           }
         }
       }
-      
+
       return true;
     }
+
+    function initialiseFromUrl() {
+      var sharedState = StateLink.readStateFromUrl();
+      if (!sharedState) {
+        return;
+      }
+
+      if (sharedState.board) {
+        board = StateLink.normaliseBoard(sharedState.board);
+      }
+      if (sharedState.currentPlayer) {
+        currentPlayer = sharedState.currentPlayer;
+      }
+      if (sharedState.scores) {
+        scores = {
+          X: sharedState.scores.X,
+          O: sharedState.scores.O,
+          draws: sharedState.scores.draws
+        };
+      }
+    }
+
+    function initialise() {
+      initialiseFromUrl();
+      updateBoardUI();
+      updateScoreboard();
+      updateGameMessage();
+
+      resetButton.addEventListener('click', resetBoard);
+      copyLinkButton.addEventListener('click', handleCopyLink);
+    }
+
+    initialise();
+
+    window.makeMove = makeMove;
   </script>
 </body>
 </html>

--- a/site/js/share/stateLink.js
+++ b/site/js/share/stateLink.js
@@ -1,0 +1,183 @@
+(function (global) {
+  var BOARD_PARAM = 'board';
+  var PLAYER_PARAM = 'player';
+  var SCORE_KEYS = {
+    X: 'sx',
+    O: 'so',
+    draws: 'sd'
+  };
+
+  function normaliseBoard(board) {
+    if (!Array.isArray(board) || board.length !== 3) {
+      return createEmptyBoard();
+    }
+
+    return board.map(function (row) {
+      if (!Array.isArray(row) || row.length !== 3) {
+        return ['', '', ''];
+      }
+
+      return row.map(function (cell) {
+        return cell === 'X' || cell === 'O' ? cell : '';
+      });
+    });
+  }
+
+  function createEmptyBoard() {
+    return [
+      ['', '', ''],
+      ['', '', ''],
+      ['', '', '']
+    ];
+  }
+
+  function encodeBoard(board) {
+    var flattened = [];
+    for (var i = 0; i < 3; i++) {
+      for (var j = 0; j < 3; j++) {
+        var value = board[i] && board[i][j];
+        flattened.push(value === 'X' || value === 'O' ? value : '-');
+      }
+    }
+    return flattened.join('');
+  }
+
+  function decodeBoard(encoded) {
+    if (typeof encoded !== 'string' || encoded.length !== 9) {
+      return null;
+    }
+
+    var board = createEmptyBoard();
+    for (var i = 0; i < encoded.length; i++) {
+      var char = encoded.charAt(i);
+      if (char !== 'X' && char !== 'O' && char !== '-') {
+        return null;
+      }
+      var row = Math.floor(i / 3);
+      var col = i % 3;
+      board[row][col] = char === '-' ? '' : char;
+    }
+
+    return board;
+  }
+
+  function encodeScores(scores) {
+    var params = new URLSearchParams();
+    if (!scores || typeof scores !== 'object') {
+      scores = { X: 0, O: 0, draws: 0 };
+    }
+
+    params.set(SCORE_KEYS.X, Number(scores.X) || 0);
+    params.set(SCORE_KEYS.O, Number(scores.O) || 0);
+    params.set(SCORE_KEYS.draws, Number(scores.draws) || 0);
+
+    var serialized = params.toString();
+    return serialized ? '#' + serialized : '';
+  }
+
+  function decodeScores(hash) {
+    if (typeof hash !== 'string' || hash.length === 0) {
+      return null;
+    }
+
+    var params = new URLSearchParams(hash.replace(/^#/, ''));
+    var x = Number(params.get(SCORE_KEYS.X));
+    var o = Number(params.get(SCORE_KEYS.O));
+    var draws = Number(params.get(SCORE_KEYS.draws));
+
+    if (!isFinite(x) || !isFinite(o) || !isFinite(draws)) {
+      return null;
+    }
+
+    return {
+      X: Math.max(0, Math.floor(x)),
+      O: Math.max(0, Math.floor(o)),
+      draws: Math.max(0, Math.floor(draws))
+    };
+  }
+
+  function decodePlayer(player) {
+    if (player === 'X' || player === 'O') {
+      return player;
+    }
+    return null;
+  }
+
+  function buildShareUrl(state) {
+    var url = new URL(global.location.href);
+    var board = state && Array.isArray(state.board) ? state.board : createEmptyBoard();
+    var player = state && state.currentPlayer ? state.currentPlayer : 'X';
+    var scores = state && state.scores ? state.scores : { X: 0, O: 0, draws: 0 };
+
+    url.searchParams.set(BOARD_PARAM, encodeBoard(board));
+    url.searchParams.set(PLAYER_PARAM, decodePlayer(player) || 'X');
+    url.hash = encodeScores(scores);
+
+    return url.toString();
+  }
+
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      try {
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        var successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (successful) {
+          resolve();
+        } else {
+          reject(new Error('Copy command was unsuccessful'));
+        }
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  function copyStateLink(state) {
+    var link = buildShareUrl(state);
+    return copyToClipboard(link).then(function () {
+      return link;
+    });
+  }
+
+  function readStateFromUrl() {
+    try {
+      var url = new URL(global.location.href);
+      var boardParam = url.searchParams.get(BOARD_PARAM);
+      var playerParam = url.searchParams.get(PLAYER_PARAM);
+      var board = decodeBoard(boardParam);
+      var player = decodePlayer(playerParam);
+      var scores = decodeScores(url.hash);
+
+      return {
+        board: board,
+        currentPlayer: player,
+        scores: scores
+      };
+    } catch (err) {
+      return {
+        board: null,
+        currentPlayer: null,
+        scores: null
+      };
+    }
+  }
+
+  global.StateLink = {
+    buildShareUrl: buildShareUrl,
+    copyStateLink: copyStateLink,
+    readStateFromUrl: readStateFromUrl,
+    createEmptyBoard: createEmptyBoard,
+    normaliseBoard: normaliseBoard
+  };
+})(window);


### PR DESCRIPTION
## Summary
- add a StateLink helper that serializes the board, active player, and scores into the URL and copies it to the clipboard
- extend the UI with a scoreboard, reset/share controls, and messaging for copy status
- restore the game state from shared URLs while handling malformed data safely

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df2b44c4a083288f18354bcf086d85