### PR TITLE
Improve board accessibility with ARIA grid roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,119 +1,94 @@
-
-
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
   <title>Tic Tac Toe</title>
   <style>
+    :root {
+      color-scheme: light dark;
+    }
+
     body {
       font-family: Arial, sans-serif;
       text-align: center;
       margin-top: 100px;
     }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
+
+    main {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
     }
-    .board td {
+
+    .board {
+      display: inline-flex;
+      flex-direction: column;
+      border: 2px solid #ccc;
+      border-right: none;
+      border-bottom: none;
+    }
+
+    .board__row {
+      display: flex;
+    }
+
+    .board__cell {
       width: 100px;
       height: 100px;
-      border: 2px solid #ccc;
+      border-right: 2px solid #ccc;
+      border-bottom: 2px solid #ccc;
       font-size: 48px;
       text-align: center;
-      vertical-align: middle;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       cursor: pointer;
+      background-color: #fff;
+      color: #333;
+      padding: 0;
+      transition: background-color 0.2s ease;
     }
-    
-    .board td:hover {
+
+    .board__row:last-child .board__cell {
+      border-bottom: none;
+    }
+
+    .board__cell:last-child {
+      border-right: none;
+    }
+
+    .board__cell:hover:not(:disabled),
+    .board__cell:focus-visible {
       background-color: #f2f2f2;
+      outline: 3px solid #4c9aff;
+      outline-offset: -3px;
     }
-    
+
+    .board__cell:disabled {
+      cursor: default;
+      background-color: #fafafa;
+      color: #555;
+    }
+
     .message {
-      margin-top: 20px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 1.5em;
     }
   </style>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <main>
+    <div
+      id="board"
+      class="board"
+      role="grid"
+      aria-label="Tic Tac Toe board. X's turn."
+    ></div>
+    <div class="message" role="status" aria-live="polite"></div>
+  </main>
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
-        }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
-        }
-      }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
-          }
-        }
-      }
-      
-      return true;
-    }
-  </script>
+  <script src="site/js/ui/uiController.js"></script>
 </body>
 </html>

--- a/site/js/ui/uiController.js
+++ b/site/js/ui/uiController.js
@@ -1,0 +1,175 @@
+(function () {
+  'use strict';
+
+  var BOARD_SIZE = 3;
+  var boardElement = document.getElementById('board');
+  var messageElement = document.querySelector('.message');
+
+  if (!boardElement || !messageElement) {
+    return;
+  }
+
+  var state = {
+    board: createEmptyBoard(),
+    currentPlayer: 'X',
+    gameOver: false
+  };
+
+  initialiseBoard();
+  updateMessage("Player X's turn");
+  syncBoardLabel();
+  syncBoardInteractivity();
+
+  function createEmptyBoard() {
+    var rows = [];
+    for (var r = 0; r < BOARD_SIZE; r += 1) {
+      var row = [];
+      for (var c = 0; c < BOARD_SIZE; c += 1) {
+        row.push('');
+      }
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  function initialiseBoard() {
+    boardElement.innerHTML = '';
+
+    for (var rowIndex = 0; rowIndex < BOARD_SIZE; rowIndex += 1) {
+      var rowElement = document.createElement('div');
+      rowElement.className = 'board__row';
+      rowElement.setAttribute('role', 'row');
+
+      for (var columnIndex = 0; columnIndex < BOARD_SIZE; columnIndex += 1) {
+        var cellButton = document.createElement('button');
+        cellButton.type = 'button';
+        cellButton.className = 'board__cell';
+        cellButton.dataset.row = String(rowIndex);
+        cellButton.dataset.col = String(columnIndex);
+        cellButton.setAttribute('role', 'gridcell');
+        cellButton.addEventListener('click', handleCellClick);
+        updateCellVisual(cellButton, '');
+        rowElement.appendChild(cellButton);
+      }
+
+      boardElement.appendChild(rowElement);
+    }
+  }
+
+  function handleCellClick(event) {
+    var cell = event.currentTarget;
+    var row = Number(cell.dataset.row);
+    var col = Number(cell.dataset.col);
+
+    if (state.gameOver || state.board[row][col]) {
+      return;
+    }
+
+    placeMark(row, col, state.currentPlayer);
+
+    if (checkWin(state.currentPlayer)) {
+      state.gameOver = true;
+      updateMessage(state.currentPlayer + ' Wins!');
+    } else if (checkDraw()) {
+      state.gameOver = true;
+      updateMessage("It's a draw!");
+    } else {
+      state.currentPlayer = state.currentPlayer === 'X' ? 'O' : 'X';
+      updateMessage('Player ' + state.currentPlayer + "'s turn");
+    }
+
+    syncBoardLabel();
+    syncBoardInteractivity();
+  }
+
+  function placeMark(row, col, mark) {
+    state.board[row][col] = mark;
+    var cell = getCellElement(row, col);
+    if (cell) {
+      updateCellVisual(cell, mark);
+    }
+  }
+
+  function updateCellVisual(cell, mark) {
+    cell.textContent = mark;
+    updateCellLabel(cell, mark);
+  }
+
+  function updateCellLabel(cell, mark) {
+    var row = Number(cell.dataset.row) + 1;
+    var col = Number(cell.dataset.col) + 1;
+    var description = mark ? 'Marked ' + mark : 'Empty';
+    cell.setAttribute('aria-label', 'Row ' + row + ', Column ' + col + '. ' + description + '.');
+  }
+
+  function syncBoardLabel() {
+    var label;
+    if (state.gameOver) {
+      if (checkWin('X')) {
+        label = "Tic Tac Toe board. Game over. X wins.";
+      } else if (checkWin('O')) {
+        label = "Tic Tac Toe board. Game over. O wins.";
+      } else {
+        label = 'Tic Tac Toe board. Game over. Draw.';
+      }
+    } else {
+      label = 'Tic Tac Toe board. ' + state.currentPlayer + "'s turn.";
+    }
+
+    boardElement.setAttribute('aria-label', label);
+  }
+
+  function syncBoardInteractivity() {
+    var cells = boardElement.querySelectorAll('.board__cell');
+    for (var i = 0; i < cells.length; i += 1) {
+      var cell = cells[i];
+      var row = Number(cell.dataset.row);
+      var col = Number(cell.dataset.col);
+      var isMarked = Boolean(state.board[row][col]);
+      var disabled = state.gameOver || isMarked;
+
+      cell.disabled = disabled;
+      cell.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      updateCellLabel(cell, state.board[row][col]);
+    }
+  }
+
+  function getCellElement(row, col) {
+    return boardElement.querySelector('.board__cell[data-row="' + row + '"][data-col="' + col + '"]');
+  }
+
+  function checkWin(player) {
+    for (var i = 0; i < BOARD_SIZE; i += 1) {
+      if (state.board[i][0] === player && state.board[i][1] === player && state.board[i][2] === player) {
+        return true;
+      }
+      if (state.board[0][i] === player && state.board[1][i] === player && state.board[2][i] === player) {
+        return true;
+      }
+    }
+
+    if (state.board[0][0] === player && state.board[1][1] === player && state.board[2][2] === player) {
+      return true;
+    }
+    if (state.board[0][2] === player && state.board[1][1] === player && state.board[2][0] === player) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function checkDraw() {
+    for (var row = 0; row < BOARD_SIZE; row += 1) {
+      for (var col = 0; col < BOARD_SIZE; col += 1) {
+        if (!state.board[row][col]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function updateMessage(text) {
+    messageElement.textContent = text;
+  }
+})();


### PR DESCRIPTION
## Summary
- replace the static table board with ARIA grid markup that exposes button cells and accessible status messaging
- add a UI controller that manages ARIA labels, disabled states, and board announcements as moves are made

## Testing
- Manual testing: not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df2b475d9c8328b84e2d25611170cf