### PR TITLE
Improve Tic Tac Toe accessibility and theme styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,119 +1,244 @@
-
-
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Tic Tac Toe</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
-    }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
-    }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
-      cursor: pointer;
-    }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
-    }
-    
-    .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
-    }
-  </style>
-</head>
-<body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Accessible Tic Tac Toe</title>
+    <link rel="stylesheet" href="site/css/theme.css" />
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <p id="board-instructions" class="board__instructions">
+      Use the arrow keys to move around the grid and press Enter or Space to place your mark.
+    </p>
+    <div
+      class="board"
+      role="grid"
+      aria-label="Tic tac toe board"
+      aria-describedby="board-instructions"
+    >
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="0"
+        data-col="0"
+        aria-rowindex="1"
+        aria-colindex="1"
+        aria-label="Row 1 column 1"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="0"
+        data-col="1"
+        aria-rowindex="1"
+        aria-colindex="2"
+        aria-label="Row 1 column 2"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="0"
+        data-col="2"
+        aria-rowindex="1"
+        aria-colindex="3"
+        aria-label="Row 1 column 3"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="1"
+        data-col="0"
+        aria-rowindex="2"
+        aria-colindex="1"
+        aria-label="Row 2 column 1"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="1"
+        data-col="1"
+        aria-rowindex="2"
+        aria-colindex="2"
+        aria-label="Row 2 column 2"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="1"
+        data-col="2"
+        aria-rowindex="2"
+        aria-colindex="3"
+        aria-label="Row 2 column 3"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="2"
+        data-col="0"
+        aria-rowindex="3"
+        aria-colindex="1"
+        aria-label="Row 3 column 1"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="2"
+        data-col="1"
+        aria-rowindex="3"
+        aria-colindex="2"
+        aria-label="Row 3 column 2"
+        aria-pressed="false"
+      ></button>
+      <button
+        type="button"
+        class="cell"
+        role="gridcell"
+        data-row="2"
+        data-col="2"
+        aria-rowindex="3"
+        aria-colindex="3"
+        aria-label="Row 3 column 3"
+        aria-pressed="false"
+      ></button>
+    </div>
+    <div class="message" role="status" aria-live="polite" aria-atomic="true"></div>
+    <script>
+      const SIZE = 3;
+      const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(""));
+      let currentPlayer = "X";
+      let gameOver = false;
 
-  <script>
-    var currentPlayer = 'X';
-    var board = [
-      ['', '', ''],
-      ['', '', ''],
-      ['', '', '']
-    ];
-    var gameOver = false;
-    
-    function makeMove(row, col) {
-      if (gameOver || board[row][col] !== '') {
-        return;
-      }
-      
-      board[row][col] = currentPlayer;
-      document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
-      if (checkWin(currentPlayer)) {
-        document.querySelector('.message').textContent = currentPlayer + ' Wins!';
-        gameOver = true;
-      } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
-        gameOver = true;
-      } else {
-        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-      }
-    }
-    
-    function checkWin(player) {
-      for (var i = 0; i < 3; i++) {
-        if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
-          return true; // Horizontal
+      const messageEl = document.querySelector(".message");
+      const cells = Array.from(document.querySelectorAll(".cell"));
+
+      const boardElement = document.querySelector(".board");
+      boardElement.addEventListener("keydown", (event) => {
+        const target = event.target;
+        if (!target.classList.contains("cell")) {
+          return;
         }
-        if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
-          return true; // Vertical
+        const row = Number(target.dataset.row);
+        const col = Number(target.dataset.col);
+
+        let nextRow = row;
+        let nextCol = col;
+
+        switch (event.key) {
+          case "ArrowUp":
+            nextRow = (row + SIZE - 1) % SIZE;
+            break;
+          case "ArrowDown":
+            nextRow = (row + 1) % SIZE;
+            break;
+          case "ArrowLeft":
+            nextCol = (col + SIZE - 1) % SIZE;
+            break;
+          case "ArrowRight":
+            nextCol = (col + 1) % SIZE;
+            break;
+          default:
+            return;
         }
+
+        const nextButton = cells.find(
+          (button) => Number(button.dataset.row) === nextRow && Number(button.dataset.col) === nextCol
+        );
+
+        if (nextButton) {
+          nextButton.focus();
+          event.preventDefault();
+        }
+      });
+
+      function updateMessage(text) {
+        messageEl.textContent = text;
       }
-      
-      if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
-        return true; // Diagonal
-      }
-      if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
-        return true; // Diagonal
-      }
-      
-      return false;
-    }
-    
-    function checkDraw() {
-      for (var i = 0; i < 3; i++) {
-        for (var j = 0; j < 3; j++) {
-          if (board[i][j] === '') {
-            return false;
+
+      function checkWin(player) {
+        for (let i = 0; i < SIZE; i += 1) {
+          if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
+            return true;
+          }
+          if (board[0][i] === player && board[1][i] === player && board[2][i] === player) {
+            return true;
           }
         }
+
+        if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
+          return true;
+        }
+        if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
+          return true;
+        }
+
+        return false;
       }
-      
-      return true;
-    }
-  </script>
-</body>
+
+      function checkDraw() {
+        return board.every((row) => row.every((cell) => cell !== ""));
+      }
+
+      function handleMove(button) {
+        if (gameOver) {
+          return;
+        }
+
+        const row = Number(button.dataset.row);
+        const col = Number(button.dataset.col);
+
+        if (board[row][col] !== "") {
+          return;
+        }
+
+        board[row][col] = currentPlayer;
+        button.textContent = currentPlayer;
+        button.setAttribute("aria-pressed", "true");
+        button.disabled = true;
+
+        if (checkWin(currentPlayer)) {
+          updateMessage(`Player ${currentPlayer} wins!`);
+          gameOver = true;
+          return;
+        }
+
+        if (checkDraw()) {
+          updateMessage("It's a draw!");
+          gameOver = true;
+          return;
+        }
+
+        currentPlayer = currentPlayer === "X" ? "O" : "X";
+        updateMessage(`Player ${currentPlayer}'s turn`);
+      }
+
+      cells.forEach((button) => {
+        button.addEventListener("click", () => handleMove(button));
+        button.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handleMove(button);
+          }
+        });
+      });
+
+      updateMessage(`Player ${currentPlayer}'s turn`);
+      cells[0].focus();
+    </script>
+  </body>
 </html>

--- a/site/css/theme.css
+++ b/site/css/theme.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: light dark;
+  --color-bg: #f5f7fa;
+  --color-surface: #ffffff;
+  --color-surface-alt: #e3e9f7;
+  --color-border: #274060;
+  --color-text: #111827;
+  --color-muted: #3b475c;
+  --color-accent: #0b57d0;
+  --color-on-accent: #ffffff;
+  --color-focus: #1f6feb;
+  --shadow-focus: rgba(31, 111, 235, 0.35);
+  --spacing-unit: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1.25rem;
+  --transition-base: 150ms ease;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0b1120;
+  --color-surface: #161f3c;
+  --color-surface-alt: #1d2747;
+  --color-border: #5b7fcc;
+  --color-text: #f5f7fa;
+  --color-muted: #d8e0ff;
+  --color-accent: #7aa2ff;
+  --color-on-accent: #0b1120;
+  --shadow-focus: rgba(31, 111, 235, 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --color-bg: #0b1120;
+    --color-surface: #161f3c;
+    --color-surface-alt: #1d2747;
+    --color-border: #5b7fcc;
+    --color-text: #f5f7fa;
+    --color-muted: #d8e0ff;
+    --color-accent: #7aa2ff;
+    --color-on-accent: #0b1120;
+    --shadow-focus: rgba(31, 111, 235, 0.5);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--spacing-unit) * 6) calc(var(--spacing-unit) * 3);
+  gap: calc(var(--spacing-unit) * 4);
+}
+
+h1 {
+  font-size: clamp(2rem, 2.5vw + 1.5rem, 3rem);
+  margin: 0;
+}
+
+.message {
+  font-size: 1.5rem;
+  font-weight: 600;
+  min-height: 2rem;
+  color: var(--color-accent);
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, clamp(5rem, 22vw, 7rem));
+  gap: calc(var(--spacing-unit) / 2);
+  padding: calc(var(--spacing-unit) / 2);
+  border-radius: var(--radius-lg);
+  background: var(--color-border);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.16);
+}
+
+.board__instructions {
+  margin: 0;
+  max-width: 28rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.board button {
+  width: clamp(5rem, 22vw, 7rem);
+  height: clamp(5rem, 22vw, 7rem);
+  border: none;
+  border-radius: calc(var(--radius-md) / 2);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color var(--transition-base), color var(--transition-base), transform var(--transition-base);
+}
+
+.board button:hover {
+  background: var(--color-surface-alt);
+}
+
+.board button:active {
+  transform: scale(0.97);
+}
+
+.board button[disabled] {
+  cursor: not-allowed;
+  background: var(--color-surface);
+  color: var(--color-muted);
+}
+
+.board button[aria-pressed="true"] {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+:where(a, button, input, select, textarea, summary, [tabindex="0"], [role="button"]) {
+  outline: none;
+}
+
+:where(a, button, input, select, textarea, summary, [tabindex="0"], [role="button"]):focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px var(--shadow-focus);
+}
+
+:where(a, button, input, select, textarea, summary, [tabindex="0"], [role="button"]):not(:focus-visible) {
+  box-shadow: none;
+}
+
+button {
+  font: inherit;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add a reusable theme stylesheet with WCAG AA-compliant color tokens and shared focus outlines
- refactor the game board markup to use interactive buttons with ARIA roles and keyboard movement support
- hook the page up to the new theme and surface clear live messaging for game status

## Testing
- npx pa11y -c /tmp/pa11y.config.json file:///workspace/tictactoe/index.html

------
https://chatgpt.com/codex/tasks/task_e_68df2b4886608328abd0f7746975d394