### PR TITLE
Add PWA install button and refresh the about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,40 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tic Tac Toe</title>
+  <script src="site/js/pwa/install.js" defer></script>
   <style>
+    :root {
+      color-scheme: light dark;
+    }
+
     body {
       font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 40px 16px 80px;
       text-align: center;
-      margin-top: 100px;
+      background: linear-gradient(180deg, #ffffff 0%, #f4f4f4 100%);
+      color: #222;
     }
+
+    h1 {
+      margin-bottom: 16px;
+      font-size: 2.5rem;
+    }
+
+    main {
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
     .board {
       display: inline-block;
       border-collapse: collapse;
+      box-shadow: 0 12px 35px rgba(0, 0, 0, 0.12);
     }
+
     .board td {
       width: 100px;
       height: 100px;
@@ -22,38 +45,121 @@
       text-align: center;
       vertical-align: middle;
       cursor: pointer;
+      background-color: rgba(255, 255, 255, 0.85);
+      transition: background-color 0.2s ease;
     }
-    
+
     .board td:hover {
-      background-color: #f2f2f2;
+      background-color: #e9f4ff;
     }
-    
+
     .message {
       margin-top: 20px;
       font-size: 24px;
       font-weight: bold;
+      min-height: 1.2em;
+    }
+
+    .about {
+      margin-top: 48px;
+      padding: 24px;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.75);
+      box-shadow: 0 6px 25px rgba(0, 0, 0, 0.08);
+    }
+
+    .about h2 {
+      margin-top: 0;
+      font-size: 1.75rem;
+    }
+
+    .about p {
+      margin: 0 auto 24px;
+      max-width: 420px;
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+
+    .install-button {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 12px 20px;
+      border: none;
+      border-radius: 9999px;
+      background: #2563eb;
+      color: #fff;
+      font-size: 1rem;
+      font-weight: bold;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    }
+
+    .install-button:hover,
+    .install-button:focus-visible {
+      background-color: #1d4ed8;
+      box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+      transform: translateY(-1px);
+      outline: none;
+    }
+
+    .install-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.7;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .install-button.is-visible {
+      display: inline-flex;
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 32px 12px 60px;
+      }
+
+      .board td {
+        width: 80px;
+        height: 80px;
+        font-size: 40px;
+      }
     }
   </style>
 </head>
 <body>
-  <table class="board">
-    <tr>
-      <td onclick="makeMove(0, 0)"></td>
-      <td onclick="makeMove(0, 1)"></td>
-      <td onclick="makeMove(0, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(1, 0)"></td>
-      <td onclick="makeMove(1, 1)"></td>
-      <td onclick="makeMove(1, 2)"></td>
-    </tr>
-    <tr>
-      <td onclick="makeMove(2, 0)"></td>
-      <td onclick="makeMove(2, 1)"></td>
-      <td onclick="makeMove(2, 2)"></td>
-    </tr>
-  </table>
-  <div class="message"></div>
+  <main>
+    <h1>Tic Tac Toe</h1>
+    <table class="board" aria-label="Tic Tac Toe board">
+      <tr>
+        <td onclick="makeMove(0, 0)" role="button" aria-label="Row 1 Column 1"></td>
+        <td onclick="makeMove(0, 1)" role="button" aria-label="Row 1 Column 2"></td>
+        <td onclick="makeMove(0, 2)" role="button" aria-label="Row 1 Column 3"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(1, 0)" role="button" aria-label="Row 2 Column 1"></td>
+        <td onclick="makeMove(1, 1)" role="button" aria-label="Row 2 Column 2"></td>
+        <td onclick="makeMove(1, 2)" role="button" aria-label="Row 2 Column 3"></td>
+      </tr>
+      <tr>
+        <td onclick="makeMove(2, 0)" role="button" aria-label="Row 3 Column 1"></td>
+        <td onclick="makeMove(2, 1)" role="button" aria-label="Row 3 Column 2"></td>
+        <td onclick="makeMove(2, 2)" role="button" aria-label="Row 3 Column 3"></td>
+      </tr>
+    </table>
+    <div class="message" aria-live="polite"></div>
+    <section class="about">
+      <h2>Play anywhere</h2>
+      <p>
+        Add Tic Tac Toe to your home screen to play even when you are offline. When your browser is ready, an
+        install button will appear below so you can keep the game a tap away.
+      </p>
+      <button class="install-button" type="button" data-install-button aria-hidden="true">
+        Install Tic Tac Toe
+      </button>
+    </section>
+  </main>
 
   <script>
     var currentPlayer = 'X';

--- a/site/js/pwa/install.js
+++ b/site/js/pwa/install.js
@@ -1,0 +1,56 @@
+(function () {
+  const installButton = document.querySelector('[data-install-button]');
+  if (!installButton) {
+    return;
+  }
+
+  let deferredPrompt = null;
+
+  const hideInstallButton = () => {
+    installButton.classList.remove('is-visible');
+    installButton.setAttribute('aria-hidden', 'true');
+    installButton.disabled = false;
+  };
+
+  const showInstallButton = () => {
+    installButton.classList.add('is-visible');
+    installButton.removeAttribute('aria-hidden');
+    installButton.disabled = false;
+  };
+
+  hideInstallButton();
+
+  installButton.addEventListener('click', async () => {
+    if (!deferredPrompt) {
+      return;
+    }
+
+    installButton.disabled = true;
+
+    deferredPrompt.prompt();
+
+    try {
+      const choiceResult = await deferredPrompt.userChoice;
+      if (choiceResult && choiceResult.outcome === 'accepted') {
+        hideInstallButton();
+      }
+    } catch (error) {
+      console.warn('PWA installation prompt was not completed.', error);
+    } finally {
+      deferredPrompt = null;
+      installButton.disabled = false;
+      hideInstallButton();
+    }
+  });
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    showInstallButton();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    hideInstallButton();
+  });
+})();


### PR DESCRIPTION
## Summary
- capture the `beforeinstallprompt` event and expose an install button for eligible browsers
- add an About section that explains how to add the game to the home screen and hooks up the button
- refresh styling to frame the board and supporting content

## Testing
- Manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68df2b4e18c88328a62b82e1b5cf8080