### PR TITLE
Make tic-tac-toe board responsive and accessible

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,39 +1,10 @@
-
-
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tic Tac Toe</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      margin-top: 100px;
-    }
-    .board {
-      display: inline-block;
-      border-collapse: collapse;
-    }
-    .board td {
-      width: 100px;
-      height: 100px;
-      border: 2px solid #ccc;
-      font-size: 48px;
-      text-align: center;
-      vertical-align: middle;
-      cursor: pointer;
-    }
-    
-    .board td:hover {
-      background-color: #f2f2f2;
-    }
-    
-    .message {
-      margin-top: 20px;
-      font-size: 24px;
-      font-weight: bold;
-    }
-  </style>
+  <link rel="stylesheet" href="site/css/style.css">
 </head>
 <body>
   <table class="board">
@@ -63,26 +34,26 @@
       ['', '', '']
     ];
     var gameOver = false;
-    
+
     function makeMove(row, col) {
       if (gameOver || board[row][col] !== '') {
         return;
       }
-      
+
       board[row][col] = currentPlayer;
       document.querySelector('.board').rows[row].cells[col].textContent = currentPlayer;
-      
+
       if (checkWin(currentPlayer)) {
         document.querySelector('.message').textContent = currentPlayer + ' Wins!';
         gameOver = true;
       } else if (checkDraw()) {
-        document.querySelector('.message').textContent = 'It's a draw!';
+        document.querySelector('.message').textContent = "It's a draw!";
         gameOver = true;
       } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
       }
     }
-    
+
     function checkWin(player) {
       for (var i = 0; i < 3; i++) {
         if (board[i][0] === player && board[i][1] === player && board[i][2] === player) {
@@ -92,17 +63,17 @@
           return true; // Vertical
         }
       }
-      
+
       if (board[0][0] === player && board[1][1] === player && board[2][2] === player) {
         return true; // Diagonal
       }
       if (board[0][2] === player && board[1][1] === player && board[2][0] === player) {
         return true; // Diagonal
       }
-      
+
       return false;
     }
-    
+
     function checkDraw() {
       for (var i = 0; i < 3; i++) {
         for (var j = 0; j < 3; j++) {
@@ -111,7 +82,7 @@
           }
         }
       }
-      
+
       return true;
     }
   </script>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,54 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 6vw, 48px);
+  font-family: Arial, sans-serif;
+  background: #f9f9f9;
+  color: #222;
+}
+
+.board {
+  width: min(90vw, 90vh, 600px);
+  height: min(90vw, 90vh, 600px);
+  min-width: 132px;
+  min-height: 132px;
+  border-collapse: collapse;
+  table-layout: fixed;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  background: #fff;
+}
+
+.board tr {
+  height: calc(100% / 3);
+}
+
+.board td {
+  border: 2px solid #ccc;
+  font-size: clamp(2.5rem, 10vw, 4rem);
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  width: calc(100% / 3);
+  height: 100%;
+  min-width: 44px;
+  min-height: 44px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.board td:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.message {
+  margin-top: clamp(16px, 5vw, 32px);
+  font-size: clamp(1.25rem, 4vw, 2rem);
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add a dedicated stylesheet and viewport meta tag for the tic-tac-toe page
- scale the game board with the viewport while preserving its 1:1 aspect ratio and minimum touch target sizes
- refresh surrounding layout styles for consistent presentation across devices

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68df2b3ebd6c83288e1962ce29c496a4