### PR TITLE
Document offline capabilities and privacy assurances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # tictactoe
 ![image](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
-
 https://alex-unnippillil.github.io/tictactoe/
+
+## Privacy and Offline Use
+- This is a fully static app that can be installed or saved for offline play with no loss of functionality.
+- All state is stored locally in the browser (settings and scores only), and nothing is synchronized to any server or analytics provider.
+- There are no third-party trackers, embedded ad networks, or bundled SDKs collecting data.
+- The project does not require API keys, remote services, or any form of online data collection.


### PR DESCRIPTION
## Summary
- add a README section explaining the app is static and offline-capable
- note that only local storage is used for settings/scores with no trackers or API keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2bab565c8328848e7e18ddfe4649