### PR TITLE
Fix GitHub Pages workflow to publish static site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,13 +27,15 @@ jobs:
 
       - name: Build site artifact
         run: |
-          mkdir -p site
-          cp index.html site/index.html
+          set -euo pipefail
+          rm -rf dist
+          mkdir -p dist
+          cp -R site/. dist/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: site/
+          path: dist/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 artifacts/
+dist/


### PR DESCRIPTION
## Summary
- ensure the GitHub Pages workflow stages the contents of the prebuilt `site/` directory
- ignore the generated deployment directory locally so it does not pollute commits

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df3530b42883289a326c1a88a077bb