### PR TITLE
Update README quick start to match package scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,62 +4,50 @@
 [![Pages Deployment](https://img.shields.io/github/actions/workflow/status/Alex-Unnippillil/tictactoe/pages.yml?branch=main&label=Pages)](https://github.com/Alex-Unnippillil/tictactoe/actions/workflows/pages.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-![image](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
+![Screenshot of the Tic Tac Toe board](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
 
-SPDX-License-Identifier: MIT
-
-![image](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
 https://alex-unnippillil.github.io/tictactoe/
 
 ## Static site assets
 
 The `site/` directory contains supplemental static files such as `robots.txt` and `sitemap.xml`. Include this folder when publishing or deploying the site so search engines can access these resources.
-## License
-
-This project is licensed under the [MIT License](LICENSE).
-# Tic Tac Toe
-
-![Screenshot of the Tic Tac Toe board](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
-
 ## Project Purpose
 
 Tic Tac Toe is a tiny web project that demonstrates the full lifecycle of building, testing, and deploying a simple interactive game. It is intentionally lightweight, making it ideal for experimenting with static site hosting on GitHub Pages or for showcasing basic DOM manipulation with vanilla JavaScript.
 
 ## Quick Start
 
-1. Install dependencies with `npm install`.
-2. Launch the local development server with `npm run dev` and open the provided URL in your browser.
-3. Make changes to `index.html`; the development server will automatically reload the page.
+1. Install dependencies (none are required, but `npm install` will ensure the lockfile is honored).
+2. Serve the static site locally with `npm run serve`.
+3. Open the reported URL (defaults to `http://127.0.0.1:8080`) to interact with the game.
 
-> **Prerequisites:** Node.js 18+ and npm 9+.
+> **Prerequisites:** Node.js 18+ and npm 9+ to run the bundled scripts.
 
 ## Scripts
 
 | Command | Description |
 | --- | --- |
-| `npm run dev` | Starts the local development server for iterative work.
-| `npm run build` | Produces the production-ready static assets.
-| `npm run test` | Executes the automated test suite.
-| `npm run lint` | Runs linting to ensure code quality and consistency.
-| `npm run deploy` | Publishes the `dist/` output to GitHub Pages.
+| `npm run serve` | Starts a local static file server for the contents of `site/`.
+| `npm run lint` | Placeholder script that currently reports linting is not configured.
+| `npm run test` | Placeholder script that notes unit tests are not yet configured.
+| `npm run e2e` | Placeholder script indicating end-to-end tests are not yet configured.
 
 ## Local Development
 
-- **Start a hot-reloading server:** `npm run dev`
-- **Run linters while developing:** `npm run lint`
-- **Format and lint before committing:** `npm run lint && npm run test`
+- **Serve the static files:** `npm run serve`
+- **Check placeholder scripts:** `npm run lint`, `npm run test`, or `npm run e2e`
 
 ## Testing
 
-- **Unit tests:** `npm run test`
+- **Placeholder unit tests:** `npm run test`
+- **Placeholder end-to-end tests:** `npm run e2e`
 - **Continuous integration:** See the workflows in `.github/workflows/` for Pages deployment.
 
 ## Deployment Overview
 
-1. Build the project locally with `npm run build` to generate optimized assets.
-2. Preview the static bundle by serving the `dist/` directory locally if desired.
-3. Deploy the latest build using `npm run deploy`, which pushes the generated content to the GitHub Pages branch.
-4. GitHub Actions workflows automate deployment to ensure the published site stays in sync with the main branch.
+1. Update the static assets inside the `site/` directory as needed.
+2. Preview changes locally with `npm run serve`.
+3. Push commits to `main`; GitHub Actions publishes the `site/` contents to the `gh-pages` branch automatically.
 
 ## Architecture Overview
 
@@ -70,10 +58,8 @@ The project is a static HTML application comprised of:
 
 ## GitHub Pages URL
 
-> Placeholder: Update this section with the final published GitHub Pages link when available.
+The latest build is always available at [alex-unnippillil.github.io/tictactoe](https://alex-unnippillil.github.io/tictactoe/).
 
 ## License
 
-SPDX-License-Identifier: MIT
-
-A dedicated `LICENSE` file will be added to outline the full MIT license terms.
+This project is distributed under the MIT License; see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- align the Quick Start and Scripts sections of the README with the available npm commands
- remove duplicate imagery and placeholder guidance in favor of a single up-to-date screenshot and live URL
- reference the existing LICENSE file directly instead of repeating placeholder text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df3a3c57708328b5de9ab941c4056f