### PR TITLE
chore: add editorconfig for formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,jsx,ts,tsx,css,scss,html,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ npx serve .
 Then visit `http://localhost:3000`.
 
 ### Linting and formatting
+Editor defaults are captured in the repository's [`.editorconfig`](./.editorconfig), which enforces UTF-8 encoding, LF line endings, final newlines, and two-space indentation for web assets and config files. Most modern editors detect this automatically.
+
 Run the following commands from the project root before committing:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a repository-level .editorconfig to enforce consistent encoding, line endings, final newlines, and two-space indentation
- note the new editor configuration in the contributing guide so editors and contributors know what to expect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3a4053d883288f28591ecd8aa032