### PR TITLE
Configure Playwright E2E test runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,73 @@
   "packages": {
     "": {
       "name": "tictactoe",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "lint": "echo \"No lint script configured\"",
     "test": "echo \"No unit tests configured\"",
-    "e2e": "echo \"No end-to-end tests configured\"",
+    "e2e": "npx playwright test",
+    "e2e:ci": "npx playwright test --reporter=line",
     "serve": "npx http-server site"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:8080';
+const webServerURL = process.env.PLAYWRIGHT_WEBSERVER_URL ?? new URL('/404.html', baseURL).toString();
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  use: {
+    baseURL,
+  },
+  webServer: {
+    command: 'npm run serve',
+    url: webServerURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration that spins up the static server and points tests at tests/e2e
- wire npm e2e scripts to the shared Playwright config and add the @playwright/test dev dependency

## Testing
- npm run e2e *(fails: missing Playwright browser system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df3a4202748328befc069afe1915c9