### PR TITLE
Add Playwright caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,16 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
       - name: Run end-to-end tests
         run: npm run e2e:ci


### PR DESCRIPTION
## Summary
- ensure the CI workflow caches Playwright browser binaries for faster setup
- install Playwright browsers before executing the end-to-end suite while keeping lint and unit tests in place

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a446adc8328b1f7eac7d5a60c27