### PR TITLE
ci: configure npm caching for node workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
       - name: Install dependencies
         run: echo "No dependencies to install"
 


### PR DESCRIPTION
## Summary
- ensure the CI workflow configures `actions/setup-node@v4` with npm caching and dependency paths
- add the same caching configuration to the Pages build job for consistency

## Testing
- not run (not needed for workflow changes)


------
https://chatgpt.com/codex/tasks/task_e_68df3a446fe0832886709e52e4887cfc