### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,34 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    name: Run Lighthouse against GitHub Pages
+    runs-on: ubuntu-latest
+    env:
+      PAGES_URL: https://alex-unnippillil.github.io/tictactoe/
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Lighthouse CI
+        run: npx lhci autorun --collect.url="$PAGES_URL" --upload.target=filesystem --upload.outputDir=./lighthouse-report
+
+      - name: Upload Lighthouse report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: lighthouse-report
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Tic Tac Toe is a tiny web project that demonstrates the full lifecycle of buildi
 - **Unit tests:** `npm run test`
 - **Continuous integration:** See the workflows in `.github/workflows/` for Pages deployment.
 
+## Lighthouse audits
+
+A dedicated [Lighthouse CI workflow](.github/workflows/lighthouse.yml) runs `npx lhci autorun` against the deployed GitHub Pages site at `https://alex-unnippillil.github.io/tictactoe/`. The job uploads the HTML report as an artifact named **`lighthouse-report`** so you can review the latest accessibility, performance, best practices, and SEO scores for the production build.
+
+To inspect the results for any run:
+
+1. Open the workflow run in GitHub Actions.
+2. Scroll to the **Artifacts** section and download **`lighthouse-report`**.
+3. Extract the archive locally and open `report.html` in your browser to view the full Lighthouse dashboard.
+
 ## Deployment Overview
 
 1. Build the project locally with `npm run build` to generate optimized assets.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Lighthouse CI against the deployed Pages site
- publish the generated HTML report as a downloadable artifact
- document how to download and review the artifact in the README

## Testing
- not run (workflow automation only)


------
https://chatgpt.com/codex/tasks/task_e_68df3a479d5c8328bec28df33f80158d