### PR TITLE
feat: add state helpers and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "lint": "echo \"No lint script configured\"",
-    "test": "echo \"No unit tests configured\"",
+    "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",
     "serve": "npx http-server site"
   }

--- a/site/js/core/state.js
+++ b/site/js/core/state.js
@@ -1,0 +1,62 @@
+'use strict';
+
+(function (global) {
+  const BOARD_SIZE = 3;
+  const PLAYER_X = 'X';
+  const PLAYER_O = 'O';
+
+  function createEmptyBoard() {
+    return Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+  }
+
+  function cloneBoard(board) {
+    if (!Array.isArray(board)) {
+      throw new TypeError('Board must be an array');
+    }
+    return board.map((row) => {
+      if (!Array.isArray(row)) {
+        throw new TypeError('Board rows must be arrays');
+      }
+      return row.slice();
+    });
+  }
+
+  function currentPlayer(board, startingPlayer = PLAYER_X) {
+    const opponent = startingPlayer === PLAYER_X ? PLAYER_O : PLAYER_X;
+    let startingCount = 0;
+    let opponentCount = 0;
+
+    for (let r = 0; r < board.length; r += 1) {
+      const row = board[r];
+      if (!Array.isArray(row)) {
+        continue;
+      }
+      for (let c = 0; c < row.length; c += 1) {
+        const cell = row[c];
+        if (cell === startingPlayer) {
+          startingCount += 1;
+        } else if (cell === opponent) {
+          opponentCount += 1;
+        }
+      }
+    }
+
+    if (startingCount <= opponentCount) {
+      return startingPlayer;
+    }
+    return opponent;
+  }
+
+  const api = {
+    createEmptyBoard,
+    cloneBoard,
+    currentPlayer
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.TicTacToe = global.TicTacToe || {};
+    global.TicTacToe.state = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,45 @@
+'use strict';
+
+(function (global) {
+  const stateModule =
+    typeof module !== 'undefined' && module.exports
+      ? require('./core/state.js')
+      : (global.TicTacToe && global.TicTacToe.state);
+
+  if (!stateModule) {
+    throw new Error('State helpers are not available');
+  }
+
+  const { createEmptyBoard, cloneBoard, currentPlayer } = stateModule;
+
+  function createInitialState() {
+    const initialBoard = createEmptyBoard();
+    return {
+      board: initialBoard,
+      history: [cloneBoard(initialBoard)],
+      get currentPlayer() {
+        return currentPlayer(this.board);
+      }
+    };
+  }
+
+  const gameState = createInitialState();
+
+  function resetGame() {
+    const nextBoard = createEmptyBoard();
+    gameState.board = nextBoard;
+    gameState.history = [cloneBoard(nextBoard)];
+  }
+
+  const api = {
+    state: gameState,
+    reset: resetGame
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.TicTacToe = global.TicTacToe || {};
+    global.TicTacToe.game = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/unit/state.test.js
+++ b/tests/unit/state.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createEmptyBoard,
+  cloneBoard,
+  currentPlayer,
+} = require('../../site/js/core/state.js');
+
+test('createEmptyBoard returns an empty 3x3 grid of nulls', () => {
+  const board = createEmptyBoard();
+
+  assert.strictEqual(Array.isArray(board), true, 'board should be an array');
+  assert.strictEqual(board.length, 3, 'board should contain three rows');
+  board.forEach((row, rowIndex) => {
+    assert.strictEqual(Array.isArray(row), true, `row ${rowIndex} should be an array`);
+    assert.strictEqual(row.length, 3, `row ${rowIndex} should contain three cells`);
+    row.forEach((cell, cellIndex) => {
+      assert.strictEqual(cell, null, `cell ${rowIndex},${cellIndex} should be null`);
+    });
+  });
+
+  const [firstRow, secondRow, thirdRow] = board;
+  assert.notStrictEqual(firstRow, secondRow, 'rows must be different references');
+  assert.notStrictEqual(secondRow, thirdRow, 'rows must be different references');
+});
+
+test('cloneBoard returns a deep copy and does not mutate the original', () => {
+  const board = createEmptyBoard();
+  board[0][0] = 'X';
+  board[1][1] = 'O';
+
+  const cloned = cloneBoard(board);
+
+  assert.deepStrictEqual(cloned, board, 'clone should match the original board');
+  assert.notStrictEqual(cloned, board, 'clone should not reference the original board');
+  assert.notStrictEqual(cloned[0], board[0], 'rows should be cloned');
+
+  cloned[0][0] = 'O';
+  assert.strictEqual(board[0][0], 'X', 'mutating the clone should not affect the original');
+});
+
+test('currentPlayer alternates between X and O based on board occupancy', () => {
+  const emptyBoard = createEmptyBoard();
+  assert.strictEqual(currentPlayer(emptyBoard), 'X', 'X should start on an empty board');
+
+  const boardAfterX = cloneBoard(emptyBoard);
+  boardAfterX[0][0] = 'X';
+  assert.strictEqual(currentPlayer(boardAfterX), 'O', 'O should play after X');
+
+  const boardAfterXO = cloneBoard(boardAfterX);
+  boardAfterXO[0][1] = 'O';
+  assert.strictEqual(currentPlayer(boardAfterXO), 'X', 'X should play after O');
+
+  const boardWithCustomStart = cloneBoard(boardAfterXO);
+  boardWithCustomStart[2][2] = 'X';
+  assert.strictEqual(
+    currentPlayer(boardWithCustomStart, 'O'),
+    'O',
+    'custom starting player should be honoured when counts are equal'
+  );
+});


### PR DESCRIPTION
## Summary
- add pure state helpers for creating, cloning, and reading the current board state
- update the game bootstrap logic to use the shared helpers and reset workflow
- cover the state helpers with unit tests and wire them into the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a48a3088328b5f34605ceffe6b0