### PR TITLE
Add game history manager with undo/redo support

### DIFF
--- a/site/js/core/history.js
+++ b/site/js/core/history.js
@@ -1,0 +1,152 @@
+'use strict';
+
+(function (global) {
+  const DEFAULT_OPTIONS = {
+    clone: null,
+    capacity: Infinity,
+  };
+
+  function defaultClone(value) {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function normaliseOptions(options) {
+    const merged = { ...DEFAULT_OPTIONS, ...(options || {}) };
+
+    if (merged.clone == null) {
+      merged.clone = defaultClone;
+    }
+
+    if (typeof merged.clone !== 'function') {
+      throw new TypeError('History clone option must be a function.');
+    }
+
+    if (!Number.isFinite(merged.capacity) || merged.capacity <= 0) {
+      merged.capacity = Infinity;
+    }
+
+    return merged;
+  }
+
+  function ensureInitialState(state) {
+    if (typeof state === 'undefined') {
+      throw new Error('createHistory requires an initial state.');
+    }
+  }
+
+  function createHistory(initialState, options) {
+    ensureInitialState(initialState);
+
+    const settings = normaliseOptions(options);
+    const { clone } = settings;
+    let capacity = settings.capacity;
+
+    let baseline = clone(initialState);
+    let past = [clone(initialState)];
+    let future = [];
+
+    function trimPast() {
+      if (!Number.isFinite(capacity)) {
+        return;
+      }
+      while (past.length > capacity) {
+        past.shift();
+      }
+    }
+
+    function getCurrentSnapshot() {
+      return past[past.length - 1];
+    }
+
+    function getCurrent() {
+      return clone(getCurrentSnapshot());
+    }
+
+    function push(state) {
+      const snapshot = clone(state);
+      past.push(snapshot);
+      future = [];
+      trimPast();
+      return getCurrent();
+    }
+
+    function canUndo() {
+      return past.length > 1;
+    }
+
+    function canRedo() {
+      return future.length > 0;
+    }
+
+    function undo() {
+      if (!canUndo()) {
+        return null;
+      }
+      const current = past.pop();
+      future.push(current);
+      return getCurrent();
+    }
+
+    function redo() {
+      if (!canRedo()) {
+        return null;
+      }
+      const next = future.pop();
+      past.push(next);
+      return clone(next);
+    }
+
+    function reset(state) {
+      baseline = clone(state);
+      past = [clone(state)];
+      future = [];
+      return getCurrent();
+    }
+
+    function replaceCurrent(state) {
+      past[past.length - 1] = clone(state);
+      future = [];
+      return getCurrent();
+    }
+
+    function clear() {
+      past = [clone(baseline)];
+      future = [];
+      return getCurrent();
+    }
+
+    function getLength() {
+      return past.length;
+    }
+
+    return {
+      push,
+      undo,
+      redo,
+      reset,
+      replaceCurrent,
+      clear,
+      canUndo,
+      canRedo,
+      getCurrent,
+      getLength,
+      _debug: {
+        past: () => past.map((entry) => clone(entry)),
+        future: () => future.map((entry) => clone(entry)),
+      },
+    };
+  }
+
+  const api = {
+    createHistory,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.GameHistory = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,162 @@
+'use strict';
+
+(function (global) {
+  const BOARD_SIZE = 3;
+  const LOG_PREFIX = '[game]';
+
+  function createEmptyBoard() {
+    return Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(''));
+  }
+
+  function createInitialState() {
+    return {
+      board: createEmptyBoard(),
+      currentPlayer: 'X',
+      winner: null,
+      moveCount: 0,
+    };
+  }
+
+  function cloneState(value) {
+    if (typeof global.structuredClone === 'function') {
+      return global.structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const historyApi = global.GameHistory;
+
+    if (!historyApi || typeof historyApi.createHistory !== 'function') {
+      console.error(`${LOG_PREFIX} Unable to initialise history; GameHistory.createHistory is missing.`);
+      return;
+    }
+
+    const history = historyApi.createHistory(createInitialState());
+    let lastKnownState = history.getCurrent();
+
+    const undoButton = document.querySelector('[data-action="undo"]');
+    const redoButton = document.querySelector('[data-action="redo"]');
+
+    function cloneForConsumers(state) {
+      return cloneState(state);
+    }
+
+    function refreshControls() {
+      if (undoButton) {
+        undoButton.disabled = !history.canUndo();
+        undoButton.setAttribute('aria-disabled', undoButton.disabled ? 'true' : 'false');
+      }
+      if (redoButton) {
+        redoButton.disabled = !history.canRedo();
+        redoButton.setAttribute('aria-disabled', redoButton.disabled ? 'true' : 'false');
+      }
+    }
+
+    function notify(reason) {
+      lastKnownState = history.getCurrent();
+      const detailState = cloneForConsumers(lastKnownState);
+      document.dispatchEvent(
+        new CustomEvent('game:state-changed', {
+          detail: {
+            state: detailState,
+            canUndo: history.canUndo(),
+            canRedo: history.canRedo(),
+            reason,
+          },
+        })
+      );
+      refreshControls();
+      return detailState;
+    }
+
+    function handleUndoRequest(source) {
+      const snapshot = history.undo();
+      if (!snapshot) {
+        return null;
+      }
+      return notify(source || 'undo');
+    }
+
+    function handleRedoRequest(source) {
+      const snapshot = history.redo();
+      if (!snapshot) {
+        return null;
+      }
+      return notify(source || 'redo');
+    }
+
+    const controller = {
+      getState() {
+        return cloneForConsumers(lastKnownState);
+      },
+      recordState(state, options = {}) {
+        if (options?.replace) {
+          history.replaceCurrent(state);
+        } else {
+          history.push(state);
+        }
+        return notify(options?.reason || (options?.replace ? 'replace' : 'record'));
+      },
+      undo() {
+        return handleUndoRequest('undo');
+      },
+      redo() {
+        return handleRedoRequest('redo');
+      },
+      reset(nextState) {
+        const targetState = nextState ? nextState : createInitialState();
+        history.reset(targetState);
+        return notify('reset');
+      },
+      canUndo() {
+        return history.canUndo();
+      },
+      canRedo() {
+        return history.canRedo();
+      },
+      getHistoryLength() {
+        return history.getLength();
+      },
+    };
+
+    function attachButtonHandlers() {
+      if (undoButton) {
+        undoButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          handleUndoRequest('undo-button');
+        });
+      }
+      if (redoButton) {
+        redoButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          handleRedoRequest('redo-button');
+        });
+      }
+    }
+
+    function attachEventHandlers() {
+      document.addEventListener('game:undo-requested', (event) => {
+        if (event) {
+          event.preventDefault?.();
+        }
+        handleUndoRequest('undo-event');
+      });
+
+      document.addEventListener('game:redo-requested', (event) => {
+        if (event) {
+          event.preventDefault?.();
+        }
+        handleRedoRequest('redo-event');
+      });
+    }
+
+    attachButtonHandlers();
+    attachEventHandlers();
+    refreshControls();
+
+    global.GameController = controller;
+
+    notify('init');
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/unit/history.test.js
+++ b/tests/unit/history.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createHistory } = require('../../site/js/core/history.js');
+
+function createBoardState(turn = 'X', placements = []) {
+  const size = 3;
+  const board = Array.from({ length: size }, () => Array(size).fill(''));
+
+  placements.forEach(({ row, col, value }) => {
+    board[row][col] = value;
+  });
+
+  return {
+    board,
+    currentPlayer: turn,
+    winner: null,
+    moveCount: placements.length,
+  };
+}
+
+test('undo returns the previous state without mutating history', () => {
+  const initial = createBoardState('X');
+  const history = createHistory(initial);
+
+  const afterFirstMove = createBoardState('O', [
+    { row: 0, col: 0, value: 'X' },
+  ]);
+  const afterSecondMove = createBoardState('X', [
+    { row: 0, col: 0, value: 'X' },
+    { row: 1, col: 1, value: 'O' },
+  ]);
+
+  history.push(afterFirstMove);
+  history.push(afterSecondMove);
+
+  const undone = history.undo();
+  assert.deepStrictEqual(undone, afterFirstMove);
+  assert.deepStrictEqual(history.getCurrent(), afterFirstMove);
+
+  undone.board[0][0] = 'O';
+  assert.strictEqual(history.getCurrent().board[0][0], 'X');
+  assert.strictEqual(afterFirstMove.board[0][0], 'X');
+});
+
+test('redo restores a state that was previously undone', () => {
+  const initial = createBoardState('X');
+  const history = createHistory(initial);
+
+  const afterFirstMove = createBoardState('O', [
+    { row: 0, col: 0, value: 'X' },
+  ]);
+  const afterSecondMove = createBoardState('X', [
+    { row: 0, col: 0, value: 'X' },
+    { row: 1, col: 1, value: 'O' },
+  ]);
+
+  history.push(afterFirstMove);
+  history.push(afterSecondMove);
+  history.undo();
+
+  assert.ok(history.canRedo());
+
+  const redone = history.redo();
+  assert.deepStrictEqual(redone, afterSecondMove);
+  assert.deepStrictEqual(history.getCurrent(), afterSecondMove);
+
+  redone.board[1][1] = 'X';
+  assert.strictEqual(history.getCurrent().board[1][1], 'O');
+  assert.strictEqual(afterSecondMove.board[1][1], 'O');
+});
+
+test('pushing a new state after undo clears the redo stack', () => {
+  const initial = createBoardState('X');
+  const history = createHistory(initial);
+
+  const afterFirstMove = createBoardState('O', [
+    { row: 0, col: 0, value: 'X' },
+  ]);
+  const afterSecondMove = createBoardState('X', [
+    { row: 0, col: 0, value: 'X' },
+    { row: 1, col: 1, value: 'O' },
+  ]);
+  const alternateSecondMove = createBoardState('X', [
+    { row: 0, col: 0, value: 'X' },
+    { row: 0, col: 1, value: 'O' },
+  ]);
+
+  history.push(afterFirstMove);
+  history.push(afterSecondMove);
+
+  history.undo();
+  assert.ok(history.canRedo());
+
+  history.push(alternateSecondMove);
+  assert.ok(!history.canRedo());
+  assert.deepStrictEqual(history.getCurrent(), alternateSecondMove);
+});


### PR DESCRIPTION
## Summary
- add a core history module that maintains past and future stacks for board states
- integrate the history module into the game controller with undo and redo hooks
- add unit tests to ensure undo/redo restores prior board snapshots

## Testing
- node --test tests/unit/history.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df3a4a250c8328a87ac64d74a28921