### PR TITLE
feat: document board mapping and align UI indices

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "private": true,
   "scripts": {
     "lint": "echo \"No lint script configured\"",
-    "test": "echo \"No unit tests configured\"",
+    "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",
+    "e2e:ci": "npm run e2e",
     "serve": "npx http-server site"
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <main class="game">
+      <header class="game__header">
+        <h1>Tic Tac Toe</h1>
+        <button id="settingsButton" type="button">Player settings</button>
+      </header>
+
+      <section
+        class="scoreboard"
+        aria-label="Player scores"
+      >
+        <div class="scoreboard__player" data-player="X">
+          <span data-role="name" data-player="X">Player X</span>
+          <span data-role="score" data-player="X">0</span>
+        </div>
+        <div class="scoreboard__player" data-player="O">
+          <span data-role="name" data-player="O">Player O</span>
+          <span data-role="score" data-player="O">0</span>
+        </div>
+      </section>
+
+      <p id="statusMessage" role="status" aria-live="polite"></p>
+
+      <table
+        class="board"
+        role="grid"
+        data-testid="board"
+        aria-label="Tic Tac Toe board"
+      >
+        <tbody>
+          <tr>
+            <td data-testid="cell" data-index="0"></td>
+            <td data-testid="cell" data-index="1"></td>
+            <td data-testid="cell" data-index="2"></td>
+          </tr>
+          <tr>
+            <td data-testid="cell" data-index="3"></td>
+            <td data-testid="cell" data-index="4"></td>
+            <td data-testid="cell" data-index="5"></td>
+          </tr>
+          <tr>
+            <td data-testid="cell" data-index="6"></td>
+            <td data-testid="cell" data-index="7"></td>
+            <td data-testid="cell" data-index="8"></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <dialog id="settingsModal" aria-labelledby="settingsTitle">
+        <form id="settingsForm" method="dialog">
+          <h2 id="settingsTitle">Player names</h2>
+          <div class="form-control">
+            <label for="playerX">Player X</label>
+            <input id="playerX" name="playerX" maxlength="24" required />
+            <p class="form-error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="form-control">
+            <label for="playerO">Player O</label>
+            <input id="playerO" name="playerO" maxlength="24" required />
+            <p class="form-error" data-error-for="playerO" hidden></p>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Save</button>
+            <button id="settingsCancelButton" type="button">Cancel</button>
+          </div>
+        </form>
+      </dialog>
+    </main>
+
+    <script src="js/core/state.js" defer></script>
+    <script src="js/ui/board.js" defer></script>
+    <script src="js/ui/status.js" defer></script>
+    <script src="js/ui/settings.js" defer></script>
+  </body>
+</html>

--- a/site/js/core/state.js
+++ b/site/js/core/state.js
@@ -1,0 +1,99 @@
+(function (global) {
+  const BOARD_SIZE = 3;
+  const BOARD_CELL_COUNT = BOARD_SIZE * BOARD_SIZE;
+
+  /**
+   * The board is represented as a flat array of nine cells in row-major order.
+   *
+   * Index reference:
+   *   0 | 1 | 2
+   *   3 | 4 | 5
+   *   6 | 7 | 8
+   *
+   * The value at each index describes the state of that cell: "X", "O", or null.
+   */
+  const BOARD_INDEX_SEQUENCE = Object.freeze(
+    Array.from({ length: BOARD_CELL_COUNT }, (_, index) => index)
+  );
+
+  const BOARD_COORDINATES = Object.freeze(
+    BOARD_INDEX_SEQUENCE.map((index) =>
+      Object.freeze({
+        index,
+        row: Math.floor(index / BOARD_SIZE),
+        column: index % BOARD_SIZE,
+      })
+    )
+  );
+
+  const isInteger = (value) => Number.isInteger(value);
+
+  const assertValidIndex = (index) => {
+    if (!isInteger(index) || index < 0 || index >= BOARD_CELL_COUNT) {
+      throw new RangeError(
+        `Board index must be an integer between 0 and ${BOARD_CELL_COUNT - 1}, received ${index}.`
+      );
+    }
+  };
+
+  const assertValidCoordinates = (row, column) => {
+    if (!isInteger(row) || row < 0 || row >= BOARD_SIZE) {
+      throw new RangeError(
+        `Row coordinate must be an integer between 0 and ${BOARD_SIZE - 1}, received ${row}.`
+      );
+    }
+    if (!isInteger(column) || column < 0 || column >= BOARD_SIZE) {
+      throw new RangeError(
+        `Column coordinate must be an integer between 0 and ${BOARD_SIZE - 1}, received ${column}.`
+      );
+    }
+  };
+
+  const indexToCoords = (index) => {
+    assertValidIndex(index);
+    return {
+      row: Math.floor(index / BOARD_SIZE),
+      column: index % BOARD_SIZE,
+    };
+  };
+
+  const coordsToIndex = (row, column) => {
+    assertValidCoordinates(row, column);
+    return row * BOARD_SIZE + column;
+  };
+
+  const createEmptyBoard = () => Array(BOARD_CELL_COUNT).fill(null);
+
+  const cloneBoard = (board) => {
+    if (!Array.isArray(board) || board.length !== BOARD_CELL_COUNT) {
+      throw new TypeError(
+        "Board must be a flat array of nine cells when cloning the state."
+      );
+    }
+    return board.slice();
+  };
+
+  const api = Object.freeze({
+    BOARD_SIZE,
+    BOARD_CELL_COUNT,
+    BOARD_INDEX_SEQUENCE,
+    BOARD_COORDINATES,
+    indexToCoords,
+    coordsToIndex,
+    createEmptyBoard,
+    cloneBoard,
+  });
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+
+  if (global && !global.coreState) {
+    Object.defineProperty(global, "coreState", {
+      value: api,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/site/js/ui/board.js
+++ b/site/js/ui/board.js
@@ -1,0 +1,40 @@
+(function (global) {
+  const getStateApi = () => global?.coreState;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const state = getStateApi();
+    if (!state) {
+      return;
+    }
+
+    const board = document.querySelector('[data-testid="board"]');
+    if (!board) {
+      return;
+    }
+
+    const cells = board.querySelectorAll('[data-index]');
+    cells.forEach((cell) => {
+      const index = Number.parseInt(cell.getAttribute("data-index"), 10);
+      if (!Number.isInteger(index)) {
+        return;
+      }
+
+      const { row, column } = state.indexToCoords(index);
+      cell.setAttribute("data-row", String(row));
+      cell.setAttribute("data-column", String(column));
+
+      if (!cell.hasAttribute("role")) {
+        cell.setAttribute("role", "gridcell");
+      }
+      if (!cell.hasAttribute("tabindex")) {
+        cell.setAttribute("tabindex", "0");
+      }
+      if (!cell.hasAttribute("aria-label")) {
+        cell.setAttribute(
+          "aria-label",
+          `Row ${row + 1}, column ${column + 1}`
+        );
+      }
+    });
+  });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/unit/state.test.js
+++ b/tests/unit/state.test.js
@@ -1,0 +1,40 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const state = require("../../site/js/core/state.js");
+
+const expectedIndexGrid = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+];
+
+test("coordsToIndex follows a 0-8 row-major mapping", () => {
+  expectedIndexGrid.forEach((rowIndices, row) => {
+    rowIndices.forEach((expectedIndex, column) => {
+      assert.equal(
+        state.coordsToIndex(row, column),
+        expectedIndex,
+        `Expected (${row}, ${column}) to map to index ${expectedIndex}`
+      );
+    });
+  });
+});
+
+test("indexToCoords returns the original row and column", () => {
+  expectedIndexGrid.flat().forEach((index) => {
+    const { row, column } = state.indexToCoords(index);
+    assert.equal(
+      expectedIndexGrid[row][column],
+      index,
+      `Index ${index} should map back to row ${row}, column ${column}`
+    );
+  });
+});
+
+test("indexToCoords and coordsToIndex are inverses for every cell", () => {
+  state.BOARD_INDEX_SEQUENCE.forEach((index) => {
+    const { row, column } = state.indexToCoords(index);
+    assert.equal(state.coordsToIndex(row, column), index);
+  });
+});


### PR DESCRIPTION
## Summary
- add a core state module that documents the row-major 0–8 board mapping and exposes helper conversions
- ensure the rendered board markup and UI helper use the same data-index convention
- configure npm test runner and add unit coverage for the coordinate/index conversions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a4eb90883289380f100d2cf1e4c