### PR TITLE
refactor: centralize tic tac toe constants

### DIFF
--- a/site/js/ai/minimax.js
+++ b/site/js/ai/minimax.js
@@ -1,6 +1,14 @@
 'use strict';
 
 (function (global) {
+  const constants =
+    typeof module !== 'undefined' && module.exports
+      ? require('../core/constants')
+      : (global.tictactoeCore && global.tictactoeCore.constants) || {};
+
+  const PLAYER_X = constants.PLAYER_X || 'X';
+  const PLAYER_O = constants.PLAYER_O || 'O';
+
   const LOG_PREFIX = '[minimax]';
 
   const stateCache = new Map();
@@ -182,7 +190,7 @@
     }
   }
 
-  function chooseMove(board, playerSymbol = 'X', opponentSymbol = 'O') {
+  function chooseMove(board, playerSymbol = PLAYER_X, opponentSymbol = PLAYER_O) {
     let bestScore = Number.NEGATIVE_INFINITY;
     let bestMove = null;
 

--- a/site/js/core/constants.js
+++ b/site/js/core/constants.js
@@ -1,0 +1,32 @@
+(function (global) {
+  'use strict';
+
+  const PLAYER_X = 'X';
+  const PLAYER_O = 'O';
+  const PLAYER_SYMBOLS = [PLAYER_X, PLAYER_O];
+
+  const WINNING_LINES = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6]
+  ];
+
+  const api = {
+    PLAYER_O,
+    PLAYER_SYMBOLS,
+    PLAYER_X,
+    WINNING_LINES
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    const namespace = (global.tictactoeCore = global.tictactoeCore || {});
+    namespace.constants = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add `site/js/core/constants.js` to expose player symbols and winning lines for reuse
- update the minimax AI defaults to read player symbols from the shared constants module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a4e04fc83289d2cf473fcd97ef4