### PR TITLE
refactor: convert ui scripts to esm modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "description": "Tic Tac Toe project setup",
   "private": true,
+  "type": "module",
   "scripts": {
     "lint": "echo \"No lint script configured\"",
-    "test": "echo \"No unit tests configured\"",
+    "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",
     "serve": "npx http-server site"
   }

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --surface: #ffffff;
+        --surface-muted: #f3f4f6;
+        --surface-strong: #111827;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-dark: #1d4ed8;
+        --text: #111827;
+        --text-secondary: #4b5563;
+        --danger: #dc2626;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #111827;
+          --surface-muted: #1f2937;
+          --surface-strong: #f9fafb;
+          --border: #374151;
+          --accent: #3b82f6;
+          --accent-dark: #2563eb;
+          --text: #f9fafb;
+          --text-secondary: #d1d5db;
+        }
+      }
+
+      body {
+        background: var(--surface-muted);
+        color: var(--text);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 32px 16px 48px;
+        box-sizing: border-box;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+        letter-spacing: -0.015em;
+      }
+
+      .app-shell {
+        width: min(680px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: clamp(20px, 4vw, 32px);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar__title {
+        font-size: clamp(1.25rem, 2vw + 1rem, 1.5rem);
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .toolbar__actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 150ms ease, border-color 150ms ease, color 150ms ease,
+          transform 150ms ease;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .button {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .button:hover {
+        background: var(--accent-dark);
+        transform: translateY(-1px);
+      }
+
+      .button--ghost {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .button--ghost:hover {
+        background: rgba(37, 99, 235, 0.12);
+        border-color: var(--accent);
+        color: var(--accent-dark);
+      }
+
+      .scoreboard {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+      }
+
+      .scoreboard__player {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        background: var(--surface-muted);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .scoreboard__mark {
+        font-weight: 700;
+        font-size: 1.125rem;
+        color: var(--accent);
+      }
+
+      .scoreboard__name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .scoreboard__score {
+        font-weight: 700;
+        font-size: 1.35rem;
+        justify-self: end;
+      }
+
+      .status {
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        font-size: 1.05rem;
+        line-height: 1.5;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .cell {
+        aspect-ratio: 1 / 1;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        font-size: clamp(2.75rem, 9vw, 3.75rem);
+        font-weight: 600;
+        background: var(--surface-muted);
+        color: var(--surface-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 150ms ease, background 150ms ease, border-color 150ms ease,
+          color 150ms ease;
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent);
+      }
+
+      .cell[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+
+      .cell--x {
+        color: var(--accent);
+      }
+
+      .cell--o {
+        color: var(--danger);
+      }
+
+      .cell--winner {
+        background: rgba(59, 130, 246, 0.16);
+        border-color: var(--accent);
+      }
+
+      .controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .controls__group {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+        max-width: min(420px, 90vw);
+      }
+
+      dialog::backdrop {
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .modal__header {
+        padding: 24px 24px 12px;
+      }
+
+      .modal__title {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .modal__body {
+        padding: 0 24px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .modal__footer {
+        padding: 16px 24px 24px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--border);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .field label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .field input[type="text"] {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        font: inherit;
+        background: var(--surface);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+      }
+
+      .field input[type="text"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .field input[type="text"].is-invalid {
+        border-color: var(--danger);
+      }
+
+      .field__hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .field__error {
+        font-size: 0.85rem;
+        color: var(--danger);
+      }
+
+      @media (max-width: 540px) {
+        .app-shell {
+          padding: 20px 16px;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .controls__group {
+          justify-content: space-between;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <main class="app-shell">
+      <header class="toolbar">
+        <p class="toolbar__title">Friendly match</p>
+        <div class="toolbar__actions">
+          <button type="button" id="newRoundButton" class="button button--ghost">
+            New round
+          </button>
+          <button type="button" id="settingsButton" class="button button--ghost">
+            Settings
+          </button>
+        </div>
+      </header>
+
+      <section
+        class="scoreboard"
+        id="scoreboard"
+        role="region"
+        aria-label="Player scoreboard"
+      >
+        <article class="scoreboard__player scoreboard__player--x">
+          <span class="scoreboard__mark" aria-hidden="true">X</span>
+          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="X"
+            aria-label="Wins for player X"
+            >0</span
+          >
+        </article>
+        <article class="scoreboard__player scoreboard__player--o">
+          <span class="scoreboard__mark" aria-hidden="true">O</span>
+          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="O"
+            aria-label="Wins for player O"
+            >0</span
+          >
+        </article>
+      </section>
+
+      <section class="status" id="statusMessage" aria-live="polite">
+        Player X (X) to move
+      </section>
+
+      <section
+        class="board"
+        id="board"
+        role="grid"
+        aria-label="Tic Tac Toe board"
+        aria-live="polite"
+      >
+        <button type="button" class="cell" data-cell data-index="0" aria-label="Row 1 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="1" aria-label="Row 1 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="2" aria-label="Row 1 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="3" aria-label="Row 2 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="4" aria-label="Row 2 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="5" aria-label="Row 2 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="6" aria-label="Row 3 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="7" aria-label="Row 3 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="8" aria-label="Row 3 column 3"></button>
+      </section>
+
+      <footer class="controls">
+        <div class="controls__group">
+          <button type="button" id="resetScoresButton" class="button button--ghost">
+            Reset scores
+          </button>
+        </div>
+        <div class="controls__group">
+          <button type="button" id="resetGameButton" class="button">
+            Reset game
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form method="dialog" id="settingsForm" class="modal" novalidate>
+        <header class="modal__header">
+          <h2 id="settingsTitle" class="modal__title">Game settings</h2>
+        </header>
+        <section class="modal__body">
+          <p class="field__hint">
+            Update each player's display name. Leave a field blank to use the default
+            name.
+          </p>
+          <div class="field">
+            <label for="playerXName">Player X name</label>
+            <input
+              type="text"
+              id="playerXName"
+              name="playerX"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player X"
+              aria-describedby="playerXHelp playerXError"
+            />
+            <p id="playerXHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerXError" class="field__error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="field">
+            <label for="playerOName">Player O name</label>
+            <input
+              type="text"
+              id="playerOName"
+              name="playerO"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player O"
+              aria-describedby="playerOHelp playerOError"
+            />
+            <p id="playerOHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerOError" class="field__error" data-error-for="playerO" hidden></p>
+          </div>
+        </section>
+        <footer class="modal__footer">
+          <button type="button" value="cancel" class="button button--ghost" id="settingsCancelButton">
+            Cancel
+          </button>
+          <button type="submit" class="button">Save</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <script type="module" src="js/game.js"></script>
+  </body>
+</html>

--- a/site/js/core/players.js
+++ b/site/js/core/players.js
@@ -1,0 +1,24 @@
+'use strict';
+
+export const DEFAULT_PLAYER_NAMES = Object.freeze({
+  X: 'Player X',
+  O: 'Player O'
+});
+
+export function sanitiseName(value, fallback = '') {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  const safeFallback = typeof fallback === 'string' ? fallback : '';
+  return trimmed.length ? trimmed : safeFallback;
+}
+
+export function normaliseNames(names = {}, defaults = DEFAULT_PLAYER_NAMES) {
+  const resolvedDefaults = {
+    X: defaults?.X ?? DEFAULT_PLAYER_NAMES.X,
+    O: defaults?.O ?? DEFAULT_PLAYER_NAMES.O
+  };
+
+  return {
+    X: sanitiseName(names?.X ?? '', resolvedDefaults.X),
+    O: sanitiseName(names?.O ?? '', resolvedDefaults.O)
+  };
+}

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,191 @@
+'use strict';
+
+import { createStatusController } from './ui/status.js';
+import { initSettings } from './ui/settings.js';
+
+const WINNING_LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6]
+];
+
+const nextPlayer = (player) => (player === 'X' ? 'O' : 'X');
+
+function queryNameElements(doc) {
+  return {
+    X: doc.querySelector('[data-role="name"][data-player="X"]'),
+    O: doc.querySelector('[data-role="name"][data-player="O"]')
+  };
+}
+
+function queryScoreElements(doc) {
+  return {
+    X: doc.querySelector('[data-role="score"][data-player="X"]'),
+    O: doc.querySelector('[data-role="score"][data-player="O"]')
+  };
+}
+
+function clearCell(cell) {
+  cell.textContent = '';
+  cell.removeAttribute('data-mark');
+  cell.classList.remove('cell--x', 'cell--o', 'cell--winner');
+  cell.removeAttribute('aria-disabled');
+}
+
+function renderCell(cell, player) {
+  cell.textContent = player;
+  cell.dataset.mark = player;
+  cell.classList.remove('cell--x', 'cell--o');
+  cell.classList.add(player === 'X' ? 'cell--x' : 'cell--o');
+  cell.setAttribute('aria-disabled', 'true');
+}
+
+function disableAllCells(cells) {
+  cells.forEach((cell) => {
+    cell.setAttribute('aria-disabled', 'true');
+  });
+}
+
+function findWinningLine(board, player) {
+  return WINNING_LINES.find((line) => line.every((index) => board[index] === player));
+}
+
+function highlightWinner(cells, line) {
+  line.forEach((index) => {
+    cells[index].classList.add('cell--winner');
+  });
+}
+
+function isBoardFull(board) {
+  return board.every((value) => value !== null);
+}
+
+export function createGame(doc = document) {
+  if (!doc) {
+    throw new Error('A document reference is required to initialise the game.');
+  }
+
+  const cells = Array.from(doc.querySelectorAll('[data-cell]'));
+  if (cells.length !== 9) {
+    throw new Error('Expected exactly nine board cells to initialise the game.');
+  }
+
+  const newRoundButton = doc.getElementById('newRoundButton');
+  const resetScoresButton = doc.getElementById('resetScoresButton');
+  const resetGameButton = doc.getElementById('resetGameButton');
+  const statusElement = doc.getElementById('statusMessage');
+
+  const status = createStatusController({
+    document: doc,
+    statusElement,
+    nameElements: queryNameElements(doc),
+    scoreElements: queryScoreElements(doc)
+  });
+
+  let board = Array(9).fill(null);
+  let currentPlayer = 'X';
+  let gameOver = false;
+
+  const startNewRound = (startingPlayer = 'X') => {
+    board = Array(9).fill(null);
+    gameOver = false;
+    currentPlayer = startingPlayer;
+    cells.forEach((cell) => clearCell(cell));
+    status.setTurn(currentPlayer);
+  };
+
+  const resetGame = () => {
+    status.resetScores();
+    startNewRound('X');
+  };
+
+  const handleCellClick = (event) => {
+    if (gameOver) {
+      return;
+    }
+
+    const cell = event.currentTarget;
+    const index = Number(cell.dataset.index);
+
+    if (board[index]) {
+      return;
+    }
+
+    board[index] = currentPlayer;
+    renderCell(cell, currentPlayer);
+
+    const winningLine = findWinningLine(board, currentPlayer);
+    if (winningLine) {
+      highlightWinner(cells, winningLine);
+      gameOver = true;
+      status.announceWin(currentPlayer);
+      status.incrementScore(currentPlayer);
+      disableAllCells(cells);
+      return;
+    }
+
+    if (isBoardFull(board)) {
+      gameOver = true;
+      status.announceDraw();
+      disableAllCells(cells);
+      return;
+    }
+
+    currentPlayer = nextPlayer(currentPlayer);
+    status.setTurn(currentPlayer);
+  };
+
+  cells.forEach((cell) => {
+    cell.addEventListener('click', handleCellClick);
+  });
+
+  const handleNewRound = () => {
+    startNewRound('X');
+  };
+
+  const handleResetScores = () => {
+    status.resetScores();
+  };
+
+  newRoundButton?.addEventListener('click', handleNewRound);
+  resetScoresButton?.addEventListener('click', handleResetScores);
+  resetGameButton?.addEventListener('click', resetGame);
+
+  const settings = initSettings({
+    document: doc,
+    defaultNames: status.getNames(),
+    onPlayersUpdated: (names) => {
+      status.applyNames(names);
+    }
+  });
+
+  startNewRound('X');
+
+  return {
+    destroy() {
+      cells.forEach((cell) => {
+        cell.removeEventListener('click', handleCellClick);
+      });
+      newRoundButton?.removeEventListener('click', handleNewRound);
+      resetScoresButton?.removeEventListener('click', handleResetScores);
+      resetGameButton?.removeEventListener('click', resetGame);
+    },
+    getBoard: () => [...board],
+    getCurrentPlayer: () => currentPlayer,
+    getStatus: () => status,
+    resetGame,
+    startNewRound,
+    getSettings: () => settings
+  };
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    createGame(document);
+  });
+}

--- a/tests/unit/status.test.mjs
+++ b/tests/unit/status.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStatusController } from '../../site/js/ui/status.js';
+
+function createMockDocument(statusElement) {
+  return {
+    getElementById(id) {
+      if (id === 'statusMessage') {
+        return statusElement;
+      }
+      return null;
+    }
+  };
+}
+
+test('status controller updates text and scores without globals', () => {
+  const statusElement = { textContent: '' };
+  const nameElements = {
+    X: { textContent: '' },
+    O: { textContent: '' }
+  };
+  const scoreElements = {
+    X: { textContent: '' },
+    O: { textContent: '' }
+  };
+
+  const doc = createMockDocument(statusElement);
+
+  const status = createStatusController({
+    document: doc,
+    statusElement,
+    nameElements,
+    scoreElements,
+    initialNames: { X: 'Alpha', O: 'Beta' }
+  });
+
+  assert.equal(nameElements.X.textContent, 'Alpha');
+  assert.equal(nameElements.O.textContent, 'Beta');
+  assert.equal(statusElement.textContent, 'Alpha (X) to move');
+  assert.deepEqual(status.getScores(), { X: 0, O: 0 });
+
+  status.setTurn('O');
+  assert.equal(statusElement.textContent, 'Beta (O) to move');
+
+  status.incrementScore('X');
+  assert.equal(scoreElements.X.textContent, '1');
+
+  status.announceWin('O');
+  assert.match(statusElement.textContent, /Beta \(O\) wins/);
+
+  status.setTurn('X');
+  status.applyNames({ X: 'Gamma' });
+  assert.equal(nameElements.X.textContent, 'Gamma');
+  assert.match(statusElement.textContent, /Gamma \(X\) to move/);
+
+  status.resetScores();
+  assert.equal(scoreElements.X.textContent, '0');
+  assert.equal(scoreElements.O.textContent, '0');
+});


### PR DESCRIPTION
## Summary
- restore the game shell with a module entry point that wires up the board, status, and settings UIs without relying on globals
- refactor the status and settings controllers into strict ES modules backed by shared player name helpers
- configure Node to run unit tests directly against the status controller to validate the module API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a51ebb0832887bed11882228a58