### PR TITLE
Add game mode selection and persistence

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --surface: #ffffff;
+        --surface-muted: #f3f4f6;
+        --surface-strong: #111827;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-dark: #1d4ed8;
+        --text: #111827;
+        --text-secondary: #4b5563;
+        --danger: #dc2626;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #111827;
+          --surface-muted: #1f2937;
+          --surface-strong: #f9fafb;
+          --border: #374151;
+          --accent: #3b82f6;
+          --accent-dark: #2563eb;
+          --text: #f9fafb;
+          --text-secondary: #d1d5db;
+        }
+      }
+
+      body {
+        background: var(--surface-muted);
+        color: var(--text);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 32px 16px 48px;
+        box-sizing: border-box;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+        letter-spacing: -0.015em;
+      }
+
+      .app-shell {
+        width: min(680px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: clamp(20px, 4vw, 32px);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar__title {
+        font-size: clamp(1.25rem, 2vw + 1rem, 1.5rem);
+        font-weight: 600;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .toolbar__mode {
+        font-size: 0.95rem;
+        color: var(--text-secondary);
+      }
+
+      .toolbar__actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 150ms ease, border-color 150ms ease, color 150ms ease,
+          transform 150ms ease;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .button {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .button:hover {
+        background: var(--accent-dark);
+        transform: translateY(-1px);
+      }
+
+      .button--ghost {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .button--ghost:hover {
+        background: rgba(37, 99, 235, 0.12);
+        border-color: var(--accent);
+        color: var(--accent-dark);
+      }
+
+      .scoreboard {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .scoreboard__header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .scoreboard__title {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--text-secondary);
+      }
+
+      .scoreboard__mode {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-secondary);
+      }
+
+      .scoreboard__players {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+      }
+
+      .scoreboard__player {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        background: var(--surface-muted);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .scoreboard__mark {
+        font-weight: 700;
+        font-size: 1.125rem;
+        color: var(--accent);
+      }
+
+      .scoreboard__name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .scoreboard__score {
+        font-weight: 700;
+        font-size: 1.35rem;
+        justify-self: end;
+      }
+
+      .status {
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        font-size: 1.05rem;
+        line-height: 1.5;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .cell {
+        aspect-ratio: 1 / 1;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        font-size: clamp(2.75rem, 9vw, 3.75rem);
+        font-weight: 600;
+        background: var(--surface-muted);
+        color: var(--surface-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 150ms ease, background 150ms ease, border-color 150ms ease,
+          color 150ms ease;
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent);
+      }
+
+      .cell[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+
+      .cell--x {
+        color: var(--accent);
+      }
+
+      .cell--o {
+        color: var(--danger);
+      }
+
+      .cell--winner {
+        background: rgba(59, 130, 246, 0.16);
+        border-color: var(--accent);
+      }
+
+      .controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .controls__group {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+        max-width: min(420px, 90vw);
+      }
+
+      dialog::backdrop {
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .modal__header {
+        padding: 24px 24px 12px;
+      }
+
+      .modal__title {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .modal__body {
+        padding: 0 24px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .modal__footer {
+        padding: 16px 24px 24px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--border);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .field--group {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+      }
+
+      .field--group legend {
+        font-weight: 600;
+        font-size: 0.95rem;
+        padding: 0 8px;
+      }
+
+      .field label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .field input[type="text"] {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        font: inherit;
+        background: var(--surface);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+      }
+
+      .field input[type="text"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .field input[type="text"].is-invalid {
+        border-color: var(--danger);
+      }
+
+      .field__hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .field__error {
+        font-size: 0.85rem;
+        color: var(--danger);
+      }
+
+      .choices {
+        display: grid;
+        gap: 8px;
+      }
+
+      .choice {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 10px 14px;
+        background: var(--surface-muted);
+        transition: border-color 150ms ease, box-shadow 150ms ease,
+          transform 150ms ease;
+      }
+
+      .choice:hover {
+        border-color: var(--accent);
+        transform: translateY(-1px);
+      }
+
+      .choice:focus-within {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+      }
+
+      .choice input[type="radio"] {
+        accent-color: var(--accent);
+      }
+
+      .choice__label {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .choice__title {
+        font-weight: 600;
+      }
+
+      .choice__description {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      @media (max-width: 540px) {
+        .app-shell {
+          padding: 20px 16px;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .controls__group {
+          justify-content: space-between;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <main class="app-shell">
+      <header class="toolbar">
+        <p class="toolbar__title">
+          <span>Friendly match</span>
+          <span class="toolbar__mode" id="modeLabel">Human vs Human</span>
+        </p>
+        <div class="toolbar__actions">
+          <button type="button" id="newRoundButton" class="button button--ghost">
+            New round
+          </button>
+          <button type="button" id="settingsButton" class="button button--ghost">
+            Settings
+          </button>
+        </div>
+      </header>
+
+      <section
+        class="scoreboard"
+        id="scoreboard"
+        role="region"
+        aria-label="Player scoreboard"
+      >
+        <header class="scoreboard__header">
+          <p class="scoreboard__title">Scoreboard</p>
+          <p class="scoreboard__mode" id="scoreboardMode">Human vs Human</p>
+        </header>
+        <div class="scoreboard__players">
+          <article class="scoreboard__player scoreboard__player--x">
+            <span class="scoreboard__mark" aria-hidden="true">X</span>
+            <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+            <span
+              class="scoreboard__score"
+              data-role="score"
+              data-player="X"
+              aria-label="Wins for player X"
+              >0</span
+            >
+          </article>
+          <article class="scoreboard__player scoreboard__player--o">
+            <span class="scoreboard__mark" aria-hidden="true">O</span>
+            <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+            <span
+              class="scoreboard__score"
+              data-role="score"
+              data-player="O"
+              aria-label="Wins for player O"
+              >0</span
+            >
+          </article>
+        </div>
+      </section>
+
+      <section class="status" id="statusMessage" aria-live="polite">
+        Player X (X) to move
+      </section>
+
+      <section
+        class="board"
+        id="board"
+        role="grid"
+        aria-label="Tic Tac Toe board"
+        aria-live="polite"
+      >
+        <button type="button" class="cell" data-cell data-index="0" aria-label="Row 1 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="1" aria-label="Row 1 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="2" aria-label="Row 1 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="3" aria-label="Row 2 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="4" aria-label="Row 2 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="5" aria-label="Row 2 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="6" aria-label="Row 3 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="7" aria-label="Row 3 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="8" aria-label="Row 3 column 3"></button>
+      </section>
+
+      <footer class="controls">
+        <div class="controls__group">
+          <button type="button" id="resetScoresButton" class="button button--ghost">
+            Reset scores
+          </button>
+        </div>
+        <div class="controls__group">
+          <button type="button" id="resetGameButton" class="button">
+            Reset game
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form method="dialog" id="settingsForm" class="modal" novalidate>
+        <header class="modal__header">
+          <h2 id="settingsTitle" class="modal__title">Game settings</h2>
+        </header>
+        <section class="modal__body">
+          <p class="field__hint">
+            Update each player's display name. Leave a field blank to use the default
+            name.
+          </p>
+          <div class="field">
+            <label for="playerXName">Player X name</label>
+            <input
+              type="text"
+              id="playerXName"
+              name="playerX"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player X"
+              aria-describedby="playerXHelp playerXError"
+            />
+            <p id="playerXHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerXError" class="field__error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="field">
+            <label for="playerOName">Player O name</label>
+            <input
+              type="text"
+              id="playerOName"
+              name="playerO"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player O"
+              aria-describedby="playerOHelp playerOError"
+            />
+            <p id="playerOHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerOError" class="field__error" data-error-for="playerO" hidden></p>
+          </div>
+          <fieldset class="field field--group" id="modeField">
+            <legend id="modeFieldLegend">Game mode</legend>
+            <p class="field__hint">
+              Choose how you would like to play. AI difficulties use the computer for
+              player O.
+            </p>
+            <div class="choices" role="radiogroup" aria-labelledby="modeFieldLegend">
+              <label class="choice">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="human"
+                  aria-describedby="modeError"
+                  required
+                />
+                <span class="choice__label">
+                  <span class="choice__title">Human vs Human</span>
+                  <span class="choice__description">Two players share the same device.</span>
+                </span>
+              </label>
+              <label class="choice">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="easy"
+                  aria-describedby="modeError"
+                />
+                <span class="choice__label">
+                  <span class="choice__title">Easy</span>
+                  <span class="choice__description">Computer picks random legal moves.</span>
+                </span>
+              </label>
+              <label class="choice">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="medium"
+                  aria-describedby="modeError"
+                />
+                <span class="choice__label">
+                  <span class="choice__title">Medium</span>
+                  <span class="choice__description">Computer follows a basic strategy.</span>
+                </span>
+              </label>
+              <label class="choice">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="hard"
+                  aria-describedby="modeError"
+                />
+                <span class="choice__label">
+                  <span class="choice__title">Hard</span>
+                  <span class="choice__description">Computer plays optimally.</span>
+                </span>
+              </label>
+            </div>
+            <p id="modeError" class="field__error" data-error-for="mode" hidden></p>
+          </fieldset>
+        </section>
+        <footer class="modal__footer">
+          <button type="button" value="cancel" class="button button--ghost" id="settingsCancelButton">
+            Cancel
+          </button>
+          <button type="submit" class="button">Save</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <script src="js/ui/status.js" defer></script>
+    <script src="js/game.js" defer></script>
+    <script src="js/ui/settings.js" defer></script>
+  </body>
+</html>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,331 @@
+(function () {
+  const WINNING_LINES = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  const STORAGE_KEY = "tictactoe:game-state";
+  const MODE_STORAGE_KEY = "tictactoe:game-mode";
+  const DEFAULT_MODE = "human";
+  const MODE_OPTIONS = new Set(["human", "easy", "medium", "hard"]);
+
+  const nextPlayer = (player) => (player === "X" ? "O" : "X");
+
+  const normaliseBoard = (value) => {
+    if (!Array.isArray(value) || value.length !== 9) {
+      return Array(9).fill(null);
+    }
+
+    return value.map((cell) => (cell === "X" || cell === "O" ? cell : null));
+  };
+
+  const normaliseWinningLine = (value) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const filtered = value
+      .map((index) => (Number.isInteger(index) ? index : null))
+      .filter((index) => index !== null && index >= 0 && index < 9);
+
+    return filtered.length === 3 ? filtered : null;
+  };
+
+  const parseScore = (input) => {
+    const number = Number(input);
+    if (!Number.isFinite(number) || number < 0) {
+      return 0;
+    }
+
+    return Math.trunc(number);
+  };
+
+  const normaliseScores = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    return {
+      X: parseScore(value.X),
+      O: parseScore(value.O),
+    };
+  };
+
+  const normaliseMode = (value) =>
+    MODE_OPTIONS.has(value) ? value : DEFAULT_MODE;
+
+  const readPersistedMode = () => {
+    try {
+      const stored = window.localStorage.getItem(MODE_STORAGE_KEY);
+      if (!stored) {
+        return null;
+      }
+
+      return normaliseMode(stored);
+    } catch (error) {
+      console.warn("Unable to load saved game mode", error);
+      return null;
+    }
+  };
+
+  const writePersistedMode = (mode) => {
+    try {
+      window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+    } catch (error) {
+      console.warn("Unable to persist game mode", error);
+    }
+  };
+
+  const readPersistedState = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn("Unable to load saved game state", error);
+      return null;
+    }
+  };
+
+  const writePersistedState = (state) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn("Unable to persist game state", error);
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const cells = Array.from(document.querySelectorAll("[data-cell]"));
+    const newRoundButton = document.getElementById("newRoundButton");
+    const resetScoresButton = document.getElementById("resetScoresButton");
+    const resetGameButton = document.getElementById("resetGameButton");
+    const status = window.uiStatus;
+
+    if (!status) {
+      throw new Error("Status UI has not been initialised");
+    }
+
+    let board = Array(9).fill(null);
+    let currentPlayer = "X";
+    let gameOver = false;
+    let lastWinner = null;
+    let activeWinningLine = null;
+    let currentMode = readPersistedMode() ?? DEFAULT_MODE;
+
+    const updateMode = (mode) => {
+      const normalised = normaliseMode(mode);
+      currentMode = normalised;
+      if (typeof status.setMode === "function") {
+        status.setMode(normalised);
+      }
+      writePersistedMode(normalised);
+    };
+
+    updateMode(currentMode);
+
+    const disableAllCells = () => {
+      cells.forEach((cell) => {
+        cell.setAttribute("aria-disabled", "true");
+      });
+    };
+
+    const clearCell = (cell) => {
+      cell.textContent = "";
+      cell.removeAttribute("data-mark");
+      cell.classList.remove("cell--x", "cell--o", "cell--winner");
+      cell.removeAttribute("aria-disabled");
+    };
+
+    const renderCell = (cell, player) => {
+      cell.textContent = player;
+      cell.dataset.mark = player;
+      cell.classList.remove("cell--x", "cell--o");
+      cell.classList.add(player === "X" ? "cell--x" : "cell--o");
+      cell.setAttribute("aria-disabled", "true");
+    };
+
+    const findWinningLine = (player) =>
+      WINNING_LINES.find((line) => line.every((index) => board[index] === player));
+
+    const highlightWinner = (line) => {
+      activeWinningLine = [...line];
+      line.forEach((index) => {
+        cells[index].classList.add("cell--winner");
+      });
+    };
+
+    const isBoardFull = () => board.every((value) => value !== null);
+
+    const persistState = () => {
+      const state = {
+        board: [...board],
+        currentPlayer,
+        gameOver,
+        winner: lastWinner,
+        winningLine: activeWinningLine ? [...activeWinningLine] : null,
+        scores: status.getScores(),
+        mode: currentMode,
+      };
+
+      writePersistedState(state);
+    };
+
+    const restoreState = () => {
+      const saved = readPersistedState();
+      if (!saved) {
+        startNewRound();
+        return;
+      }
+
+      board = normaliseBoard(saved.board);
+      currentPlayer = saved.currentPlayer === "O" ? "O" : "X";
+      gameOver = Boolean(saved.gameOver);
+      lastWinner = saved.winner === "X" || saved.winner === "O" ? saved.winner : null;
+      activeWinningLine = normaliseWinningLine(saved.winningLine);
+
+      if (typeof saved.mode === "string") {
+        updateMode(saved.mode);
+      }
+
+      const savedScores = normaliseScores(saved.scores);
+      if (savedScores) {
+        status.setScores(savedScores);
+      } else {
+        status.resetScores();
+      }
+
+      cells.forEach((cell, index) => {
+        const mark = board[index];
+        if (mark === "X" || mark === "O") {
+          renderCell(cell, mark);
+        } else {
+          clearCell(cell);
+        }
+      });
+
+      if (gameOver) {
+        if (activeWinningLine && activeWinningLine.length === 3) {
+          highlightWinner(activeWinningLine);
+        }
+        disableAllCells();
+        if (lastWinner) {
+          status.announceWin(lastWinner);
+        } else {
+          status.announceDraw();
+        }
+      } else {
+        status.setTurn(currentPlayer);
+      }
+
+      persistState();
+    };
+
+    const startNewRound = () => {
+      board = Array(9).fill(null);
+      gameOver = false;
+      lastWinner = null;
+      activeWinningLine = null;
+      cells.forEach((cell) => clearCell(cell));
+      currentPlayer = "X";
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const resetGame = () => {
+      status.resetScores();
+      startNewRound();
+    };
+
+    const handleCellClick = (event) => {
+      if (gameOver) {
+        return;
+      }
+
+      const cell = event.currentTarget;
+      const index = Number(cell.dataset.index);
+
+      if (board[index]) {
+        return;
+      }
+
+      board[index] = currentPlayer;
+      renderCell(cell, currentPlayer);
+
+      const winningLine = findWinningLine(currentPlayer);
+      if (winningLine) {
+        highlightWinner(winningLine);
+        gameOver = true;
+        lastWinner = currentPlayer;
+        status.announceWin(currentPlayer);
+        status.incrementScore(currentPlayer);
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      if (isBoardFull()) {
+        gameOver = true;
+        lastWinner = null;
+        activeWinningLine = null;
+        status.announceDraw();
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      currentPlayer = nextPlayer(currentPlayer);
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const handleNewRound = () => {
+      startNewRound();
+    };
+
+    const handleResetGame = () => {
+      resetGame();
+    };
+
+    const handleResetScores = () => {
+      status.resetScores();
+      persistState();
+    };
+
+    cells.forEach((cell) => {
+      cell.addEventListener("click", handleCellClick);
+    });
+
+    newRoundButton?.addEventListener("click", handleNewRound);
+    resetGameButton?.addEventListener("click", handleResetGame);
+    resetScoresButton?.addEventListener("click", handleResetScores);
+
+    document.addEventListener("settings:players-updated", (event) => {
+      const modeValue = event?.detail?.mode;
+      if (typeof modeValue !== "string") {
+        return;
+      }
+      const nextMode = normaliseMode(modeValue);
+      if (nextMode === currentMode) {
+        return;
+      }
+      updateMode(nextMode);
+      persistState();
+    });
+
+    restoreState();
+  });
+})();


### PR DESCRIPTION
## Summary
- add game mode radio options to the settings modal and surface the current mode in the layout
- persist the selected game mode and broadcast it alongside player name updates
- teach the status and game controllers to reflect and save the chosen mode across sessions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68df3a5381b08328abe73eb9eed119b0