### PR TITLE
feat: add ai thinking delay and controls

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --surface: #ffffff;
+        --surface-muted: #f3f4f6;
+        --surface-strong: #111827;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-dark: #1d4ed8;
+        --text: #111827;
+        --text-secondary: #4b5563;
+        --danger: #dc2626;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #111827;
+          --surface-muted: #1f2937;
+          --surface-strong: #f9fafb;
+          --border: #374151;
+          --accent: #3b82f6;
+          --accent-dark: #2563eb;
+          --text: #f9fafb;
+          --text-secondary: #d1d5db;
+        }
+      }
+
+      body {
+        background: var(--surface-muted);
+        color: var(--text);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 32px 16px 48px;
+        box-sizing: border-box;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+        letter-spacing: -0.015em;
+      }
+
+      .app-shell {
+        width: min(680px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: clamp(20px, 4vw, 32px);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar__title {
+        font-size: clamp(1.25rem, 2vw + 1rem, 1.5rem);
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .toolbar__actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 150ms ease, border-color 150ms ease, color 150ms ease,
+          transform 150ms ease;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .button {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .button:hover {
+        background: var(--accent-dark);
+        transform: translateY(-1px);
+      }
+
+      .button--ghost {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .button--ghost:hover {
+        background: rgba(37, 99, 235, 0.12);
+        border-color: var(--accent);
+        color: var(--accent-dark);
+      }
+
+      select {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        padding: 8px 14px;
+        background: var(--surface);
+        color: var(--text);
+        cursor: pointer;
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+      }
+
+      select:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .controls__label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-secondary);
+      }
+
+      .controls__label select {
+        min-width: 150px;
+      }
+
+      .controls__label select[disabled] {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .scoreboard {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+      }
+
+      .scoreboard__player {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        background: var(--surface-muted);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .scoreboard__mark {
+        font-weight: 700;
+        font-size: 1.125rem;
+        color: var(--accent);
+      }
+
+      .scoreboard__name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .scoreboard__score {
+        font-weight: 700;
+        font-size: 1.35rem;
+        justify-self: end;
+      }
+
+      .status {
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        font-size: 1.05rem;
+        line-height: 1.5;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .cell {
+        aspect-ratio: 1 / 1;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        font-size: clamp(2.75rem, 9vw, 3.75rem);
+        font-weight: 600;
+        background: var(--surface-muted);
+        color: var(--surface-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 150ms ease, background 150ms ease, border-color 150ms ease,
+          color 150ms ease;
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent);
+      }
+
+      .cell[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+
+      .cell--x {
+        color: var(--accent);
+      }
+
+      .cell--o {
+        color: var(--danger);
+      }
+
+      .cell--winner {
+        background: rgba(59, 130, 246, 0.16);
+        border-color: var(--accent);
+      }
+
+      .controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .controls__group {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+        max-width: min(420px, 90vw);
+      }
+
+      dialog::backdrop {
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .modal__header {
+        padding: 24px 24px 12px;
+      }
+
+      .modal__title {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .modal__body {
+        padding: 0 24px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .modal__footer {
+        padding: 16px 24px 24px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--border);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .field label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .field input[type="text"] {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        font: inherit;
+        background: var(--surface);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+      }
+
+      .field input[type="text"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .field input[type="text"].is-invalid {
+        border-color: var(--danger);
+      }
+
+      .field__hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .field__error {
+        font-size: 0.85rem;
+        color: var(--danger);
+      }
+
+      @media (max-width: 540px) {
+        .app-shell {
+          padding: 20px 16px;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .controls__group {
+          justify-content: space-between;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <main class="app-shell">
+      <header class="toolbar">
+        <p class="toolbar__title">Friendly match</p>
+        <div class="toolbar__actions">
+          <button type="button" id="newRoundButton" class="button button--ghost">
+            New round
+          </button>
+          <button type="button" id="settingsButton" class="button button--ghost">
+            Settings
+          </button>
+        </div>
+      </header>
+
+      <section
+        class="scoreboard"
+        id="scoreboard"
+        role="region"
+        aria-label="Player scoreboard"
+      >
+        <article class="scoreboard__player scoreboard__player--x">
+          <span class="scoreboard__mark" aria-hidden="true">X</span>
+          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="X"
+            aria-label="Wins for player X"
+            >0</span
+          >
+        </article>
+        <article class="scoreboard__player scoreboard__player--o">
+          <span class="scoreboard__mark" aria-hidden="true">O</span>
+          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="O"
+            aria-label="Wins for player O"
+            >0</span
+          >
+        </article>
+      </section>
+
+      <section class="status" id="statusMessage" aria-live="polite">
+        Player X (X) to move
+      </section>
+
+      <section
+        class="board"
+        id="board"
+        role="grid"
+        aria-label="Tic Tac Toe board"
+        aria-live="polite"
+      >
+        <button type="button" class="cell" data-cell data-index="0" aria-label="Row 1 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="1" aria-label="Row 1 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="2" aria-label="Row 1 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="3" aria-label="Row 2 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="4" aria-label="Row 2 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="5" aria-label="Row 2 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="6" aria-label="Row 3 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="7" aria-label="Row 3 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="8" aria-label="Row 3 column 3"></button>
+      </section>
+
+      <footer class="controls">
+        <div class="controls__group">
+          <label class="controls__label" for="modeSelect">
+            <span>Game mode</span>
+            <select id="modeSelect" name="mode">
+              <option value="pvp">Player vs Player</option>
+              <option value="cpu">Player vs AI</option>
+            </select>
+          </label>
+          <label class="controls__label" for="difficultySelect">
+            <span>AI difficulty</span>
+            <select id="difficultySelect" name="difficulty" disabled>
+              <option value="easy">Easy</option>
+              <option value="normal" selected>Normal</option>
+              <option value="hard">Hard</option>
+            </select>
+          </label>
+        </div>
+        <div class="controls__group">
+          <button
+            type="button"
+            id="undoButton"
+            class="button button--ghost"
+            disabled
+          >
+            Undo move
+          </button>
+          <button type="button" id="resetScoresButton" class="button button--ghost">
+            Reset scores
+          </button>
+        </div>
+        <div class="controls__group">
+          <button type="button" id="resetGameButton" class="button">
+            Reset game
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form method="dialog" id="settingsForm" class="modal" novalidate>
+        <header class="modal__header">
+          <h2 id="settingsTitle" class="modal__title">Game settings</h2>
+        </header>
+        <section class="modal__body">
+          <p class="field__hint">
+            Update each player's display name. Leave a field blank to use the default
+            name.
+          </p>
+          <div class="field">
+            <label for="playerXName">Player X name</label>
+            <input
+              type="text"
+              id="playerXName"
+              name="playerX"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player X"
+              aria-describedby="playerXHelp playerXError"
+            />
+            <p id="playerXHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerXError" class="field__error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="field">
+            <label for="playerOName">Player O name</label>
+            <input
+              type="text"
+              id="playerOName"
+              name="playerO"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player O"
+              aria-describedby="playerOHelp playerOError"
+            />
+            <p id="playerOHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerOError" class="field__error" data-error-for="playerO" hidden></p>
+          </div>
+        </section>
+        <footer class="modal__footer">
+          <button type="button" value="cancel" class="button button--ghost" id="settingsCancelButton">
+            Cancel
+          </button>
+          <button type="submit" class="button">Save</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <script src="js/ai/minimax.js" defer></script>
+    <script src="js/ui/status.js" defer></script>
+    <script src="js/game.js" defer></script>
+    <script src="js/ui/settings.js" defer></script>
+  </body>
+</html>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,629 @@
+(function () {
+  const WINNING_LINES = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  const STORAGE_KEY = "tictactoe:game-state";
+  const MODE_PVP = "pvp";
+  const MODE_CPU = "cpu";
+  const AI_PLAYER = "O";
+  const HUMAN_PLAYER = "X";
+  const AI_DELAY_MIN = 200;
+  const AI_DELAY_MAX = 400;
+  const VALID_DIFFICULTIES = new Set(["easy", "normal", "hard"]);
+
+  const nextPlayer = (player) => (player === "X" ? "O" : "X");
+
+  const normaliseBoard = (value) => {
+    if (!Array.isArray(value) || value.length !== 9) {
+      return Array(9).fill(null);
+    }
+
+    return value.map((cell) => (cell === "X" || cell === "O" ? cell : null));
+  };
+
+  const normaliseWinningLine = (value) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const filtered = value
+      .map((index) => (Number.isInteger(index) ? index : null))
+      .filter((index) => index !== null && index >= 0 && index < 9);
+
+    return filtered.length === 3 ? filtered : null;
+  };
+
+  const parseScore = (input) => {
+    const number = Number(input);
+    if (!Number.isFinite(number) || number < 0) {
+      return 0;
+    }
+
+    return Math.trunc(number);
+  };
+
+  const normaliseScores = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    return {
+      X: parseScore(value.X),
+      O: parseScore(value.O),
+    };
+  };
+
+  const normaliseMode = (value) => (value === MODE_CPU ? MODE_CPU : MODE_PVP);
+
+  const normaliseDifficulty = (value) =>
+    VALID_DIFFICULTIES.has(value) ? value : "normal";
+
+  const readPersistedState = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn("Unable to load saved game state", error);
+      return null;
+    }
+  };
+
+  const writePersistedState = (state) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn("Unable to persist game state", error);
+    }
+  };
+
+  const boardToMatrix = (board) => {
+    const matrix = [];
+    for (let row = 0; row < 3; row += 1) {
+      const start = row * 3;
+      matrix.push([
+        board[start] ?? "",
+        board[start + 1] ?? "",
+        board[start + 2] ?? "",
+      ]);
+    }
+    return matrix;
+  };
+
+  const getEmptyIndices = (board) =>
+    board.reduce((indices, value, index) => {
+      if (!value) {
+        indices.push(index);
+      }
+      return indices;
+    }, []);
+
+  const chooseRandomMove = (board) => {
+    const empty = getEmptyIndices(board);
+    if (!empty.length) {
+      return null;
+    }
+    const randomIndex = Math.floor(Math.random() * empty.length);
+    return empty[randomIndex];
+  };
+
+  const findImmediateWinningMove = (board, player) => {
+    for (let i = 0; i < board.length; i += 1) {
+      if (board[i]) {
+        continue;
+      }
+      board[i] = player;
+      const hasWinningLine = WINNING_LINES.some((line) =>
+        line.every((index) => board[index] === player)
+      );
+      board[i] = null;
+      if (hasWinningLine) {
+        return i;
+      }
+    }
+    return null;
+  };
+
+  const chooseNormalMove = (board, aiSymbol, humanSymbol) => {
+    const winningMove = findImmediateWinningMove(board, aiSymbol);
+    if (winningMove !== null) {
+      return winningMove;
+    }
+
+    const blockingMove = findImmediateWinningMove(board, humanSymbol);
+    if (blockingMove !== null) {
+      return blockingMove;
+    }
+
+    if (!board[4]) {
+      return 4;
+    }
+
+    const preferredCorners = [0, 2, 6, 8].filter((index) => !board[index]);
+    if (preferredCorners.length) {
+      const randomIndex = Math.floor(Math.random() * preferredCorners.length);
+      return preferredCorners[randomIndex];
+    }
+
+    return chooseRandomMove(board);
+  };
+
+  const chooseMinimaxMove = (board, aiSymbol, humanSymbol) => {
+    if (!window.MinimaxAI || typeof window.MinimaxAI.chooseMove !== "function") {
+      return chooseRandomMove(board);
+    }
+
+    try {
+      const result = window.MinimaxAI.chooseMove(
+        boardToMatrix(board),
+        aiSymbol,
+        humanSymbol
+      );
+      if (!result || typeof result.row !== "number" || typeof result.col !== "number") {
+        return chooseRandomMove(board);
+      }
+      return result.row * 3 + result.col;
+    } catch (error) {
+      console.warn("Unable to calculate minimax move", error);
+      return chooseRandomMove(board);
+    }
+  };
+
+  const chooseAiMove = (board, difficulty, aiSymbol, humanSymbol) => {
+    switch (difficulty) {
+      case "easy":
+        return chooseRandomMove(board);
+      case "hard":
+        return chooseMinimaxMove(board, aiSymbol, humanSymbol);
+      case "normal":
+      default: {
+        const normalMove = chooseNormalMove(board, aiSymbol, humanSymbol);
+        if (normalMove !== null) {
+          return normalMove;
+        }
+        return chooseRandomMove(board);
+      }
+    }
+  };
+
+  const randomAiDelay = () =>
+    AI_DELAY_MIN + Math.floor(Math.random() * (AI_DELAY_MAX - AI_DELAY_MIN + 1));
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const boardElement = document.getElementById("board");
+    const cells = Array.from(document.querySelectorAll("[data-cell]"));
+    const newRoundButton = document.getElementById("newRoundButton");
+    const resetScoresButton = document.getElementById("resetScoresButton");
+    const resetGameButton = document.getElementById("resetGameButton");
+    const undoButton = document.getElementById("undoButton");
+    const modeSelect = document.getElementById("modeSelect");
+    const difficultySelect = document.getElementById("difficultySelect");
+    const status = window.uiStatus;
+
+    if (!status) {
+      throw new Error("Status UI has not been initialised");
+    }
+
+    let board = Array(9).fill(null);
+    let currentPlayer = HUMAN_PLAYER;
+    let gameOver = false;
+    let lastWinner = null;
+    let activeWinningLine = null;
+    let history = [];
+    let mode = MODE_PVP;
+    let difficulty = "normal";
+    let pendingAiTimeout = null;
+
+    const disableAllCells = () => {
+      cells.forEach((cell) => {
+        cell.setAttribute("aria-disabled", "true");
+      });
+    };
+
+    const clearCell = (cell) => {
+      cell.textContent = "";
+      cell.removeAttribute("data-mark");
+      cell.classList.remove("cell--x", "cell--o", "cell--winner");
+      cell.removeAttribute("aria-disabled");
+    };
+
+    const renderCell = (cell, player) => {
+      cell.textContent = player;
+      cell.dataset.mark = player;
+      cell.classList.remove("cell--x", "cell--o", "cell--winner");
+      cell.classList.add(player === "X" ? "cell--x" : "cell--o");
+      cell.setAttribute("aria-disabled", "true");
+    };
+
+    const clearWinnerHighlight = () => {
+      cells.forEach((cell) => {
+        cell.classList.remove("cell--winner");
+      });
+    };
+
+    const applyWinnerHighlight = () => {
+      if (!activeWinningLine) {
+        return;
+      }
+      activeWinningLine.forEach((index) => {
+        const cell = cells[index];
+        if (cell) {
+          cell.classList.add("cell--winner");
+        }
+      });
+    };
+
+    const findWinningLine = (player) =>
+      WINNING_LINES.find((line) => line.every((index) => board[index] === player));
+
+    const highlightWinner = (line) => {
+      activeWinningLine = [...line];
+      clearWinnerHighlight();
+      applyWinnerHighlight();
+    };
+
+    const isBoardFull = () => board.every((value) => value !== null);
+
+    const updateUndoButtonState = () => {
+      if (undoButton) {
+        undoButton.disabled = history.length === 0;
+      }
+    };
+
+    const persistState = () => {
+      const state = {
+        board: [...board],
+        currentPlayer,
+        gameOver,
+        winner: lastWinner,
+        winningLine: activeWinningLine ? [...activeWinningLine] : null,
+        scores: status.getScores(),
+        mode,
+        difficulty,
+      };
+
+      writePersistedState(state);
+    };
+
+    const cancelPendingAi = () => {
+      if (pendingAiTimeout !== null) {
+        window.clearTimeout(pendingAiTimeout);
+        pendingAiTimeout = null;
+      }
+      if (boardElement) {
+        boardElement.removeAttribute("data-thinking");
+      }
+      status.clearTemporaryMessage();
+    };
+
+    const isCpuMode = () => mode === MODE_CPU;
+    const isAiTurn = () => isCpuMode() && !gameOver && currentPlayer === AI_PLAYER;
+
+    const pushHistory = () => {
+      history.push({
+        board: [...board],
+        currentPlayer,
+        gameOver,
+        lastWinner,
+        activeWinningLine: activeWinningLine ? [...activeWinningLine] : null,
+        scores: status.getScores(),
+      });
+      updateUndoButtonState();
+    };
+
+    const renderBoardFromState = () => {
+      cells.forEach((cell, index) => {
+        const mark = board[index];
+        if (mark === "X" || mark === "O") {
+          renderCell(cell, mark);
+        } else {
+          clearCell(cell);
+        }
+      });
+      clearWinnerHighlight();
+      applyWinnerHighlight();
+      if (gameOver) {
+        disableAllCells();
+      }
+    };
+
+    const scheduleAiMove = () => {
+      cancelPendingAi();
+      if (!isAiTurn()) {
+        return;
+      }
+
+      if (boardElement) {
+        boardElement.setAttribute("data-thinking", "true");
+      }
+      status.showThinking();
+
+      const delay = randomAiDelay();
+      pendingAiTimeout = window.setTimeout(() => {
+        pendingAiTimeout = null;
+        if (boardElement) {
+          boardElement.removeAttribute("data-thinking");
+        }
+
+        if (!isAiTurn()) {
+          status.clearTemporaryMessage();
+          return;
+        }
+
+        const moveIndex = chooseAiMove(board, difficulty, AI_PLAYER, HUMAN_PLAYER);
+        status.clearTemporaryMessage();
+        if (moveIndex === null) {
+          return;
+        }
+        makeMove(moveIndex, { isAi: true });
+      }, delay);
+    };
+
+    const updateModeUI = () => {
+      if (modeSelect) {
+        modeSelect.value = mode;
+      }
+      if (difficultySelect) {
+        if (mode === MODE_CPU) {
+          difficultySelect.removeAttribute("disabled");
+        } else {
+          difficultySelect.setAttribute("disabled", "true");
+        }
+      }
+    };
+
+    const updateDifficultyUI = () => {
+      if (difficultySelect) {
+        difficultySelect.value = difficulty;
+      }
+    };
+
+    const startNewRound = () => {
+      cancelPendingAi();
+      board = Array(9).fill(null);
+      gameOver = false;
+      lastWinner = null;
+      activeWinningLine = null;
+      history = [];
+      cells.forEach((cell) => clearCell(cell));
+      clearWinnerHighlight();
+      currentPlayer = HUMAN_PLAYER;
+      status.setTurn(currentPlayer);
+      updateUndoButtonState();
+      persistState();
+      if (isAiTurn()) {
+        scheduleAiMove();
+      }
+    };
+
+    const restoreState = () => {
+      const saved = readPersistedState();
+      history = [];
+      updateUndoButtonState();
+      cancelPendingAi();
+
+      if (!saved) {
+        status.resetScores();
+        startNewRound();
+        return;
+      }
+
+      board = normaliseBoard(saved.board);
+      currentPlayer = saved.currentPlayer === AI_PLAYER ? AI_PLAYER : HUMAN_PLAYER;
+      gameOver = Boolean(saved.gameOver);
+      lastWinner = saved.winner === "X" || saved.winner === "O" ? saved.winner : null;
+      activeWinningLine = normaliseWinningLine(saved.winningLine);
+      mode = normaliseMode(saved.mode);
+      difficulty = normaliseDifficulty(saved.difficulty);
+
+      const savedScores = normaliseScores(saved.scores);
+      if (savedScores) {
+        status.setScores(savedScores);
+      } else {
+        status.resetScores();
+      }
+
+      renderBoardFromState();
+      updateModeUI();
+      updateDifficultyUI();
+
+      if (gameOver) {
+        if (lastWinner) {
+          status.announceWin(lastWinner);
+        } else {
+          status.announceDraw();
+        }
+      } else {
+        status.setTurn(currentPlayer);
+        if (isAiTurn()) {
+          scheduleAiMove();
+        }
+      }
+
+      persistState();
+    };
+
+    const makeMove = (index, { isAi = false } = {}) => {
+      if (gameOver || board[index]) {
+        return;
+      }
+
+      pushHistory();
+
+      board[index] = currentPlayer;
+      renderCell(cells[index], currentPlayer);
+
+      const winningLine = findWinningLine(currentPlayer);
+      if (winningLine) {
+        highlightWinner(winningLine);
+        gameOver = true;
+        lastWinner = currentPlayer;
+        status.announceWin(currentPlayer);
+        status.incrementScore(currentPlayer);
+        disableAllCells();
+        cancelPendingAi();
+        persistState();
+        updateUndoButtonState();
+        return;
+      }
+
+      if (isBoardFull()) {
+        gameOver = true;
+        lastWinner = null;
+        activeWinningLine = null;
+        clearWinnerHighlight();
+        status.announceDraw();
+        disableAllCells();
+        cancelPendingAi();
+        persistState();
+        updateUndoButtonState();
+        return;
+      }
+
+      currentPlayer = nextPlayer(currentPlayer);
+      status.setTurn(currentPlayer);
+      persistState();
+      if (!isAi && isAiTurn()) {
+        scheduleAiMove();
+      }
+      updateUndoButtonState();
+    };
+
+    const handleCellClick = (event) => {
+      if (gameOver || (isCpuMode() && currentPlayer === AI_PLAYER)) {
+        return;
+      }
+
+      const cell = event.currentTarget;
+      const index = Number(cell.dataset.index);
+      if (!Number.isInteger(index) || index < 0 || index >= board.length) {
+        return;
+      }
+
+      if (board[index]) {
+        return;
+      }
+
+      makeMove(index, { isAi: false });
+    };
+
+    const handleNewRound = () => {
+      startNewRound();
+    };
+
+    const handleResetGame = () => {
+      cancelPendingAi();
+      status.resetScores();
+      startNewRound();
+    };
+
+    const handleResetScores = () => {
+      status.resetScores();
+      persistState();
+    };
+
+    const handleUndo = () => {
+      if (!history.length) {
+        return;
+      }
+
+      cancelPendingAi();
+
+      const snapshot = history.pop();
+      board = normaliseBoard(snapshot.board);
+      currentPlayer = snapshot.currentPlayer === AI_PLAYER ? AI_PLAYER : HUMAN_PLAYER;
+      gameOver = Boolean(snapshot.gameOver);
+      lastWinner = snapshot.lastWinner === "X" || snapshot.lastWinner === "O" ? snapshot.lastWinner : null;
+      activeWinningLine = normaliseWinningLine(snapshot.activeWinningLine);
+
+      if (snapshot.scores) {
+        status.setScores(snapshot.scores);
+      } else {
+        status.resetScores();
+      }
+
+      renderBoardFromState();
+
+      if (gameOver) {
+        if (lastWinner) {
+          status.announceWin(lastWinner);
+        } else {
+          status.announceDraw();
+        }
+      } else {
+        status.setTurn(currentPlayer);
+      }
+
+      updateUndoButtonState();
+      persistState();
+
+      if (isAiTurn()) {
+        scheduleAiMove();
+      }
+    };
+
+    const handleModeChange = (event) => {
+      const nextMode = normaliseMode(event?.target?.value);
+      if (mode === nextMode) {
+        updateModeUI();
+        return;
+      }
+
+      mode = nextMode;
+      cancelPendingAi();
+      updateModeUI();
+      persistState();
+
+      if (!gameOver && isAiTurn()) {
+        scheduleAiMove();
+      }
+    };
+
+    const handleDifficultyChange = (event) => {
+      const nextDifficulty = normaliseDifficulty(event?.target?.value);
+      if (difficulty === nextDifficulty) {
+        updateDifficultyUI();
+        return;
+      }
+
+      difficulty = nextDifficulty;
+      updateDifficultyUI();
+      cancelPendingAi();
+      persistState();
+
+      if (isAiTurn()) {
+        scheduleAiMove();
+      }
+    };
+
+    cells.forEach((cell) => {
+      cell.addEventListener("click", handleCellClick);
+    });
+
+    newRoundButton?.addEventListener("click", handleNewRound);
+    resetGameButton?.addEventListener("click", handleResetGame);
+    resetScoresButton?.addEventListener("click", handleResetScores);
+    undoButton?.addEventListener("click", handleUndo);
+    modeSelect?.addEventListener("change", handleModeChange);
+    difficultySelect?.addEventListener("change", handleDifficultyChange);
+
+    updateModeUI();
+    updateDifficultyUI();
+    restoreState();
+  });
+})();

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -23,6 +23,7 @@
     let scores = { X: 0, O: 0 };
     let currentPlayer = "X";
     let statusState = "turn"; // "turn" | "win" | "draw"
+    let temporaryMessage = null;
 
     const formatTurnMessage = (player) =>
       `${playerNames[player]} (${player}) to move`;
@@ -30,6 +31,11 @@
       `${playerNames[player]} (${player}) wins this round!`;
 
     const refreshStatus = () => {
+      if (temporaryMessage) {
+        statusMessage.textContent = temporaryMessage;
+        return;
+      }
+
       switch (statusState) {
         case "win":
           statusMessage.textContent = formatWinMessage(currentPlayer);
@@ -42,6 +48,14 @@
           statusMessage.textContent = formatTurnMessage(currentPlayer);
           break;
       }
+    };
+
+    const clearTemporaryMessage = () => {
+      if (!temporaryMessage) {
+        return;
+      }
+      temporaryMessage = null;
+      refreshStatus();
     };
 
     const applyNames = (names) => {
@@ -60,15 +74,18 @@
       setTurn(player) {
         currentPlayer = player;
         statusState = "turn";
+        clearTemporaryMessage();
         refreshStatus();
       },
       announceWin(player) {
         currentPlayer = player;
         statusState = "win";
+        clearTemporaryMessage();
         refreshStatus();
       },
       announceDraw() {
         statusState = "draw";
+        clearTemporaryMessage();
         refreshStatus();
       },
       incrementScore(player) {
@@ -90,6 +107,11 @@
       getNames() {
         return { ...playerNames };
       },
+      showThinking() {
+        temporaryMessage = "AI is thinking…";
+        statusMessage.textContent = temporaryMessage;
+      },
+      clearTemporaryMessage,
     };
 
     window.uiStatus = api;


### PR DESCRIPTION
## Summary
- show a temporary "AI is thinking…" status indicator that clears when turns resume
- schedule CPU turns with a 200–400ms delay and cancel pending timeouts on reset, undo, or difficulty changes
- add undo and mode controls so the UI stays in sync with human or AI turns

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a55c4cc8328b8528995967038c9