### PR TITLE
feat: add first move heuristics for minimax ai

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "lint": "echo \"No lint script configured\"",
-    "test": "echo \"No unit tests configured\"",
+    "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",
     "serve": "npx http-server site"
   }

--- a/site/js/ai/minimax.js
+++ b/site/js/ai/minimax.js
@@ -29,6 +29,60 @@
     return board.map((row) => row.slice());
   }
 
+  function countSymbol(board, symbol) {
+    let count = 0;
+    for (let r = 0; r < board.length; r += 1) {
+      for (let c = 0; c < board[r].length; c += 1) {
+        if (board[r][c] === symbol) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  }
+
+  function isFirstMoveForSymbol(board, symbol) {
+    return countSymbol(board, symbol) === 0;
+  }
+
+  function findCenterMove(board) {
+    const size = board.length;
+    if (!size || size % 2 === 0) {
+      return null;
+    }
+
+    const centerIndex = Math.floor(size / 2);
+    if (!board[centerIndex][centerIndex]) {
+      return { row: centerIndex, col: centerIndex };
+    }
+
+    return null;
+  }
+
+  function findCornerMove(board) {
+    const size = board.length;
+    if (!size) {
+      return null;
+    }
+
+    const lastIndex = size - 1;
+    const corners = [
+      { row: 0, col: 0 },
+      { row: 0, col: lastIndex },
+      { row: lastIndex, col: 0 },
+      { row: lastIndex, col: lastIndex }
+    ];
+
+    for (let i = 0; i < corners.length; i += 1) {
+      const corner = corners[i];
+      if (!board[corner.row][corner.col]) {
+        return corner;
+      }
+    }
+
+    return null;
+  }
+
   function isBoardFull(board) {
     for (let r = 0; r < board.length; r += 1) {
       for (let c = 0; c < board[r].length; c += 1) {
@@ -185,6 +239,22 @@
   function chooseMove(board, playerSymbol = 'X', opponentSymbol = 'O') {
     let bestScore = Number.NEGATIVE_INFINITY;
     let bestMove = null;
+
+    if (isFirstMoveForSymbol(board, playerSymbol)) {
+      const centerMove = findCenterMove(board);
+      if (centerMove) {
+        const move = { ...centerMove, score: 0 };
+        logCacheStats('after chooseMove (heuristic center)');
+        return move;
+      }
+
+      const cornerMove = findCornerMove(board);
+      if (cornerMove) {
+        const move = { ...cornerMove, score: 0 };
+        logCacheStats('after chooseMove (heuristic corner)');
+        return move;
+      }
+    }
 
     for (let r = 0; r < board.length; r += 1) {
       for (let c = 0; c < board[r].length; c += 1) {

--- a/tests/unit/minimax-first-move.test.js
+++ b/tests/unit/minimax-first-move.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MinimaxAI = require(path.join(__dirname, '../../site/js/ai/minimax.js'));
+
+function createEmptyBoard() {
+  return [
+    ['', '', ''],
+    ['', '', ''],
+    ['', '', '']
+  ];
+}
+
+test('AI chooses the center on its first move when available', () => {
+  const board = createEmptyBoard();
+
+  const move = MinimaxAI.chooseMove(board, 'X', 'O');
+
+  assert.strictEqual(move.row, 1);
+  assert.strictEqual(move.col, 1);
+  assert.strictEqual(board[1][1], '');
+});
+
+test('AI selects a corner on its first move when the center is taken', () => {
+  const board = createEmptyBoard();
+  board[1][1] = 'O';
+
+  const move = MinimaxAI.chooseMove(board, 'X', 'O');
+
+  const cornerKeys = new Set(['0,0', '0,2', '2,0', '2,2']);
+  const chosenKey = `${move.row},${move.col}`;
+
+  assert.ok(cornerKeys.has(chosenKey));
+  assert.strictEqual(board[move.row][move.col], '');
+});


### PR DESCRIPTION
## Summary
- add first-move heuristics so the AI selects the center before falling back to minimax
- fall back to corner selection when the center is occupied on the opening turn
- add node-based unit tests that exercise the new opening move behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a56e0d883288ccd7fe4d09d86ad