### PR TITLE
Add animated winner highlight with reduced motion fallback

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -93,6 +93,32 @@ body {
   border-color: var(--color-accent);
 }
 
+.board td.cell--winner {
+  background-color: rgba(37, 99, 235, 0.12);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .board td.cell--winner {
+    animation: cellWinnerPulse 1.1s ease-in-out infinite alternate;
+    position: relative;
+  }
+
+  @keyframes cellWinnerPulse {
+    from {
+      box-shadow: 0 0 0 rgba(37, 99, 235, 0);
+      transform: scale(1);
+    }
+
+    to {
+      box-shadow: 0 0 1.25rem rgba(37, 99, 235, 0.35);
+      transform: scale(1.05);
+    }
+  }
+}
+
 .message {
   font-size: clamp(1.25rem, 4vw, 1.5rem);
   font-weight: 600;

--- a/tests/manual-qa.md
+++ b/tests/manual-qa.md
@@ -1,0 +1,5 @@
+# Manual QA Checklist
+
+## Visual feedback
+- [ ] Trigger a win and confirm the winning cells gain the pulsing highlight animation.
+- [ ] Enable the operating system's "Reduce motion" or similar accessibility setting, reload the game, and confirm the winning cells show the static highlight without animation.


### PR DESCRIPTION
## Summary
- add a pulse animation for winning cells on the board
- respect the prefers-reduced-motion media query to provide a static fallback
- extend the manual QA checklist with steps that cover the animation and reduced-motion behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a5a22648328a0604c66abc61dc6