### PR TITLE
Improve accessible board interactions and status announcements

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -61,6 +61,17 @@ body {
   padding: var(--spacing-lg) var(--spacing-sm);
 }
 
+dialog {
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0;
+  box-shadow: var(--shadow-soft);
+}
+
+dialog::backdrop {
+  background: rgba(17, 24, 39, 0.55);
+}
+
 .game {
   width: min(90vw, 24rem);
   background: var(--color-surface);
@@ -69,35 +80,160 @@ body {
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: var(--spacing-md);
-  justify-items: center;
+  justify-items: stretch;
+}
+
+.game__header {
+  display: grid;
+  gap: var(--spacing-xs);
+  text-align: center;
+}
+
+.message {
+  font-size: clamp(1.1rem, 4vw, 1.4rem);
+  font-weight: 600;
+  text-align: center;
+  min-height: 1.5em;
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-sm);
+}
+
+.scoreboard__player {
+  background-color: var(--color-background);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.scoreboard__name {
+  font-weight: 600;
+}
+
+.scoreboard__score {
+  font-size: 1.5rem;
+}
+
+.board-wrapper {
+  width: 100%;
 }
 
 .board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.25rem;
   width: 100%;
   aspect-ratio: 1 / 1;
-  table-layout: fixed;
 }
 
-.board td {
-  width: 33.33%;
+.cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 2px solid var(--color-border);
+  background: var(--color-surface);
   font-size: clamp(2.5rem, 8vw, 3.5rem);
-  text-align: center;
-  vertical-align: middle;
+  font-weight: 700;
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease;
+  border-radius: 0.5rem;
 }
 
-.board td:hover {
+.cell:hover,
+.cell:focus-visible {
   background-color: var(--color-border-hover);
   border-color: var(--color-accent);
 }
 
-.message {
-  font-size: clamp(1.25rem, 4vw, 1.5rem);
+.cell:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.game__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  justify-content: center;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background-color: var(--color-accent);
+  color: #ffffff;
   font-weight: 600;
-  text-align: center;
-  min-height: 1.5em;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  background-color: #1d4ed8;
+}
+
+.button--secondary {
+  background-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  background-color: #9ca3af;
+}
+
+.settings-form {
+  border: none;
+  padding: var(--spacing-md);
+  background-color: var(--color-surface);
+  display: grid;
+  gap: var(--spacing-sm);
+  min-width: min(90vw, 20rem);
+}
+
+.settings-form__description {
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.settings-form__field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.settings-form__error {
+  color: #b91c1c;
+  font-size: 0.875rem;
+}
+
+.settings-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+  padding: 0;
+}
+
+.settings-form__actions button {
+  min-width: 6rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (min-width: 48rem) {

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <link rel="stylesheet" href="./css/style.css" />
+  </head>
+  <body>
+    <main class="game" aria-labelledby="gameTitle">
+      <header class="game__header">
+        <h1 id="gameTitle">Tic Tac Toe</h1>
+        <p id="statusMessage" class="message" role="status" aria-live="polite"></p>
+        <div id="statusLiveRegion" class="sr-only" aria-live="polite"></div>
+      </header>
+
+      <section class="scoreboard" aria-label="Scoreboard">
+        <div class="scoreboard__player" data-player="X">
+          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <span class="scoreboard__score" data-role="score" data-player="X">0</span>
+        </div>
+        <div class="scoreboard__player" data-player="O">
+          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <span class="scoreboard__score" data-role="score" data-player="O">0</span>
+        </div>
+      </section>
+
+      <section class="board-wrapper">
+        <div
+          id="board"
+          class="board"
+          role="grid"
+          aria-label="Tic Tac Toe board"
+        >
+          <button type="button" class="cell" data-cell-index="0" data-row="0" data-col="0" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="1" data-row="0" data-col="1" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="2" data-row="0" data-col="2" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="3" data-row="1" data-col="0" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="4" data-row="1" data-col="1" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="5" data-row="1" data-col="2" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="6" data-row="2" data-col="0" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="7" data-row="2" data-col="1" role="gridcell"></button>
+          <button type="button" class="cell" data-cell-index="8" data-row="2" data-col="2" role="gridcell"></button>
+        </div>
+      </section>
+
+      <div class="game__actions">
+        <button type="button" id="resetButton" class="button button--reset">Reset board</button>
+        <button type="button" id="settingsButton" class="button button--settings">Player settings</button>
+      </div>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form id="settingsForm" method="dialog" class="settings-form">
+        <h2 id="settingsTitle">Player names</h2>
+        <p class="settings-form__description">
+          Update the names announced for each player. Names can include letters, numbers,
+          spaces, apostrophes, periods, or hyphens.
+        </p>
+
+        <div class="settings-form__field">
+          <label for="playerX">Player X name</label>
+          <input id="playerX" name="playerX" type="text" maxlength="24" autocomplete="off" />
+          <p class="settings-form__error" data-error-for="playerX" hidden></p>
+        </div>
+
+        <div class="settings-form__field">
+          <label for="playerO">Player O name</label>
+          <input id="playerO" name="playerO" type="text" maxlength="24" autocomplete="off" />
+          <p class="settings-form__error" data-error-for="playerO" hidden></p>
+        </div>
+
+        <menu class="settings-form__actions">
+          <button type="button" id="settingsCancelButton" class="button button--secondary">Cancel</button>
+          <button type="submit" class="button button--primary">Save</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="./js/ui/status.js" defer></script>
+    <script src="./js/ui/settings.js" defer></script>
+    <script src="./js/ui/game.js" defer></script>
+  </body>
+</html>

--- a/site/js/ui/game.js
+++ b/site/js/ui/game.js
@@ -1,0 +1,246 @@
+'use strict';
+
+(function () {
+  const BOARD_SIZE = 3;
+  const TOTAL_CELLS = BOARD_SIZE * BOARD_SIZE;
+  const DEFAULT_NAMES = {
+    X: "Player X",
+    O: "Player O",
+  };
+  const ROW_NAMES = ["top", "middle", "bottom"];
+  const COLUMN_NAMES = ["left", "center", "right"];
+
+  const getNames = () => {
+    if (window.uiStatus && typeof window.uiStatus.getNames === "function") {
+      return window.uiStatus.getNames();
+    }
+    return { ...DEFAULT_NAMES };
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const board = document.getElementById("board");
+    const resetButton = document.getElementById("resetButton");
+
+    if (!board || !resetButton) {
+      return;
+    }
+
+    const statusApi = window.uiStatus;
+    if (!statusApi) {
+      console.warn("uiStatus API is unavailable; board will not announce turns.");
+    }
+
+    const cells = Array.from(
+      board.querySelectorAll('[data-cell-index]')
+    );
+
+    if (cells.length !== TOTAL_CELLS) {
+      throw new Error(`Expected ${TOTAL_CELLS} cells but found ${cells.length}.`);
+    }
+
+    const state = {
+      board: Array(TOTAL_CELLS).fill(null),
+      currentPlayer: "X",
+      winner: null,
+      isDraw: false,
+      hasAnnouncedWin: false,
+    };
+
+    let focusedIndex = 0;
+
+    const indexToRow = (index) => Math.floor(index / BOARD_SIZE);
+    const indexToColumn = (index) => index % BOARD_SIZE;
+
+    const formatCellLabel = (index, mark) => {
+      const rowName = ROW_NAMES[indexToRow(index)] ?? `row ${indexToRow(index) + 1}`;
+      const columnName = COLUMN_NAMES[indexToColumn(index)] ?? `column ${indexToColumn(index) + 1}`;
+      const names = getNames();
+
+      if (!mark) {
+        const activeName = names[state.currentPlayer] ?? state.currentPlayer;
+        return `${rowName} ${columnName} cell. Empty. ${activeName} to move.`;
+      }
+
+      const ownerName = names[mark] ?? mark;
+      return `${rowName} ${columnName} cell. Occupied by ${ownerName} with ${mark}.`;
+    };
+
+    const updateCellAccessibility = (cell, index, mark) => {
+      cell.setAttribute("aria-label", formatCellLabel(index, mark));
+      if (mark) {
+        cell.setAttribute("aria-pressed", "true");
+        cell.setAttribute("data-player", mark);
+      } else {
+        cell.setAttribute("aria-pressed", "false");
+        cell.removeAttribute("data-player");
+      }
+      cell.disabled = Boolean(mark) || Boolean(state.winner) || state.isDraw;
+    };
+
+    const renderBoard = () => {
+      state.board.forEach((mark, index) => {
+        const cell = cells[index];
+        if (!cell) {
+          return;
+        }
+        cell.textContent = mark ? mark : "";
+        updateCellAccessibility(cell, index, mark);
+      });
+    };
+
+    const updateStatus = () => {
+      if (!statusApi) {
+        return;
+      }
+      if (state.winner) {
+        if (!state.hasAnnouncedWin) {
+          statusApi.incrementScore(state.winner);
+          state.hasAnnouncedWin = true;
+        }
+        statusApi.announceWin(state.winner);
+        return;
+      }
+      if (state.isDraw) {
+        statusApi.announceDraw();
+        return;
+      }
+      state.hasAnnouncedWin = false;
+      statusApi.setTurn(state.currentPlayer);
+    };
+
+    const focusCell = (index) => {
+      const nextIndex = Math.max(0, Math.min(TOTAL_CELLS - 1, index));
+      focusedIndex = nextIndex;
+      cells.forEach((cell, cellIndex) => {
+        cell.setAttribute("tabindex", cellIndex === focusedIndex ? "0" : "-1");
+      });
+      const nextCell = cells[focusedIndex];
+      if (nextCell) {
+        nextCell.focus();
+      }
+    };
+
+    const evaluateWinner = () => {
+      const lines = [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+        [0, 3, 6],
+        [1, 4, 7],
+        [2, 5, 8],
+        [0, 4, 8],
+        [2, 4, 6],
+      ];
+
+      for (const [a, b, c] of lines) {
+        const mark = state.board[a];
+        if (mark && mark === state.board[b] && mark === state.board[c]) {
+          state.winner = mark;
+          return;
+        }
+      }
+
+      state.winner = null;
+      state.isDraw = state.board.every(Boolean);
+    };
+
+    const isGameOver = () => Boolean(state.winner) || state.isDraw;
+
+    const handleMove = (index) => {
+      if (isGameOver() || state.board[index]) {
+        return;
+      }
+
+      state.board[index] = state.currentPlayer;
+      evaluateWinner();
+
+      if (!isGameOver()) {
+        state.currentPlayer = state.currentPlayer === "X" ? "O" : "X";
+      }
+
+      renderBoard();
+      updateStatus();
+
+      if (!isGameOver()) {
+        updateEmptyCellLabels();
+      }
+    };
+
+    const updateEmptyCellLabels = () => {
+      state.board.forEach((mark, index) => {
+        if (!mark) {
+          updateCellAccessibility(cells[index], index, mark);
+        }
+      });
+    };
+
+    const resetGame = () => {
+      state.board.fill(null);
+      state.currentPlayer = "X";
+      state.winner = null;
+      state.isDraw = false;
+      state.hasAnnouncedWin = false;
+      renderBoard();
+      updateStatus();
+      focusCell(0);
+    };
+
+    board.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLButtonElement)) {
+        return;
+      }
+      const index = Number.parseInt(target.dataset.cellIndex ?? "", 10);
+      if (Number.isNaN(index)) {
+        return;
+      }
+      handleMove(index);
+    });
+
+    board.addEventListener("keydown", (event) => {
+      const key = event.key;
+      let nextIndex = focusedIndex;
+      if (key === "ArrowRight") {
+        nextIndex = focusedIndex + 1;
+      } else if (key === "ArrowLeft") {
+        nextIndex = focusedIndex - 1;
+      } else if (key === "ArrowDown") {
+        nextIndex = focusedIndex + BOARD_SIZE;
+      } else if (key === "ArrowUp") {
+        nextIndex = focusedIndex - BOARD_SIZE;
+      } else if (key === "Home") {
+        nextIndex = Math.floor(focusedIndex / BOARD_SIZE) * BOARD_SIZE;
+      } else if (key === "End") {
+        nextIndex = Math.floor(focusedIndex / BOARD_SIZE) * BOARD_SIZE + (BOARD_SIZE - 1);
+      } else if (key === "PageUp") {
+        nextIndex = focusedIndex % BOARD_SIZE;
+      } else if (key === "PageDown") {
+        nextIndex = focusedIndex % BOARD_SIZE + BOARD_SIZE * (BOARD_SIZE - 1);
+      } else if (key === "Enter" || key === " ") {
+        event.preventDefault();
+        handleMove(focusedIndex);
+        return;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      nextIndex = ((nextIndex % TOTAL_CELLS) + TOTAL_CELLS) % TOTAL_CELLS;
+      focusCell(nextIndex);
+    });
+
+    resetButton.addEventListener("click", () => {
+      resetGame();
+    });
+
+    document.addEventListener("settings:players-updated", () => {
+      renderBoard();
+      updateEmptyCellLabels();
+      updateStatus();
+    });
+
+    renderBoard();
+    updateStatus();
+    focusCell(0);
+  });
+})();

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -6,6 +6,7 @@
 
   document.addEventListener("DOMContentLoaded", () => {
     const statusMessage = document.getElementById("statusMessage");
+    const statusLiveRegion = document.getElementById("statusLiveRegion");
     const nameElements = {
       X: document.querySelector('[data-role="name"][data-player="X"]'),
       O: document.querySelector('[data-role="name"][data-player="O"]'),
@@ -29,17 +30,34 @@
     const formatWinMessage = (player) =>
       `${playerNames[player]} (${player}) wins this round!`;
 
+    const schedule =
+      typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame.bind(window)
+        : (callback) => window.setTimeout(callback, 16);
+
+    const announce = (message) => {
+      if (statusMessage) {
+        statusMessage.textContent = message;
+      }
+      if (statusLiveRegion) {
+        statusLiveRegion.textContent = "";
+        schedule(() => {
+          statusLiveRegion.textContent = message;
+        });
+      }
+    };
+
     const refreshStatus = () => {
       switch (statusState) {
         case "win":
-          statusMessage.textContent = formatWinMessage(currentPlayer);
+          announce(formatWinMessage(currentPlayer));
           break;
         case "draw":
-          statusMessage.textContent = "It's a draw!";
+          announce("It's a draw!");
           break;
         case "turn":
         default:
-          statusMessage.textContent = formatTurnMessage(currentPlayer);
+          announce(formatTurnMessage(currentPlayer));
           break;
       }
     };


### PR DESCRIPTION
## What changed
- add an accessible tic tac toe board layout with controls, scoreboard, and settings modal markup
- introduce a game controller script that manages turns, win detection, ARIA labels, and roving focus
- enhance status messaging with a dedicated live region and refreshed styles for the board and dialog

## Why
- ensure cell announcements reflect the current mark and player
- provide a reliable live region for turn, win, and draw updates sourced from custom player names
- align ARIA usage with accessibility guidance while keeping the UI visually polished

## Screenshots
![Updated Tic Tac Toe board](browser:/invocations/yvfhpkun/artifacts/artifacts/tictactoe-board.png)

## Testing notes
- [ ] Unit tests added or updated
- [ ] E2E ran green in CI

## A11y checklist
- [ ] Focus order verified
- [x] ARIA roles and labels present
- [ ] Color contrast validated

------
https://chatgpt.com/codex/tasks/task_e_68df3a59579c83288286d69b1a189d0a