### PR TITLE
feat: add theme toggle with persistent preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Tic Tac Toe is a tiny web project that demonstrates the full lifecycle of buildi
 - **Run linters while developing:** `npm run lint`
 - **Format and lint before committing:** `npm run lint && npm run test`
 
+## Theme preferences
+
+- Use the toolbar theme toggle to switch between light and dark appearances.
+- On first visit the interface follows your system `prefers-color-scheme` setting.
+- After you toggle the theme, the preference is stored in `localStorage` and
+  continues to override the system default on subsequent visits until cleared.
+
 ## Testing
 
 - **Unit tests:** `npm run test`

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,531 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <script>
+      (function () {
+        try {
+          const stored = window.localStorage.getItem("tictactoe:theme");
+          if (stored === "light" || stored === "dark") {
+            document.documentElement.dataset.theme = stored;
+            document.documentElement.style.colorScheme = stored;
+          }
+        } catch (error) {
+          console.warn("Unable to read stored theme preference", error);
+        }
+      })();
+    </script>
+    <style>
+      :root {
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        color-scheme: light;
+        --surface: #ffffff;
+        --surface-muted: #f3f4f6;
+        --surface-strong: #111827;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-dark: #1d4ed8;
+        --text: #111827;
+        --text-secondary: #4b5563;
+        --danger: #dc2626;
+      }
+
+      :root[data-theme="dark"] {
+        color-scheme: dark;
+        --surface: #111827;
+        --surface-muted: #1f2937;
+        --surface-strong: #f9fafb;
+        --border: #374151;
+        --accent: #3b82f6;
+        --accent-dark: #2563eb;
+        --text: #f9fafb;
+        --text-secondary: #d1d5db;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root:not([data-theme]) {
+          color-scheme: dark;
+          --surface: #111827;
+          --surface-muted: #1f2937;
+          --surface-strong: #f9fafb;
+          --border: #374151;
+          --accent: #3b82f6;
+          --accent-dark: #2563eb;
+          --text: #f9fafb;
+          --text-secondary: #d1d5db;
+        }
+      }
+
+      body {
+        background: var(--surface-muted);
+        color: var(--text);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 32px 16px 48px;
+        box-sizing: border-box;
+        gap: 24px;
+        transition: background 200ms ease, color 200ms ease;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+        letter-spacing: -0.015em;
+      }
+
+      .app-shell {
+        width: min(680px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: clamp(20px, 4vw, 32px);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+        transition: background 200ms ease, border-color 200ms ease,
+          box-shadow 200ms ease;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar__title {
+        font-size: clamp(1.25rem, 2vw + 1rem, 1.5rem);
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .toolbar__actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 150ms ease, border-color 150ms ease, color 150ms ease,
+          transform 150ms ease;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .button {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .button:hover {
+        background: var(--accent-dark);
+        transform: translateY(-1px);
+      }
+
+      .button--ghost {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .button--ghost:hover {
+        background: rgba(37, 99, 235, 0.12);
+        border-color: var(--accent);
+        color: var(--accent-dark);
+      }
+
+      .button--icon {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding-inline: 14px;
+        min-height: 42px;
+      }
+
+      .button__icon {
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        border: 0;
+      }
+
+      .scoreboard {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+      }
+
+      .scoreboard__player {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        background: var(--surface-muted);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+        transition: background 200ms ease, border-color 200ms ease;
+      }
+
+      .scoreboard__mark {
+        font-weight: 700;
+        font-size: 1.125rem;
+        color: var(--accent);
+      }
+
+      .scoreboard__name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .scoreboard__score {
+        font-weight: 700;
+        font-size: 1.35rem;
+        justify-self: end;
+      }
+
+      .status {
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        font-size: 1.05rem;
+        line-height: 1.5;
+        transition: background 200ms ease, border-color 200ms ease;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .cell {
+        aspect-ratio: 1 / 1;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        font-size: clamp(2.75rem, 9vw, 3.75rem);
+        font-weight: 600;
+        background: var(--surface-muted);
+        color: var(--surface-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 150ms ease, background 150ms ease, border-color 150ms ease,
+          color 150ms ease;
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent);
+      }
+
+      .cell[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+
+      .cell--x {
+        color: var(--accent);
+      }
+
+      .cell--o {
+        color: var(--danger);
+      }
+
+      .cell--winner {
+        background: rgba(59, 130, 246, 0.16);
+        border-color: var(--accent);
+      }
+
+      .controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .controls__group {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+        max-width: min(420px, 90vw);
+      }
+
+      dialog::backdrop {
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .modal__header {
+        padding: 24px 24px 12px;
+      }
+
+      .modal__title {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .modal__body {
+        padding: 0 24px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .modal__footer {
+        padding: 16px 24px 24px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--border);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .field label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .field input[type="text"] {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        font: inherit;
+        background: var(--surface);
+        transition: border-color 150ms ease, box-shadow 150ms ease,
+          background 150ms ease;
+        color: var(--text);
+      }
+
+      .field input[type="text"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .field input[type="text"].is-invalid {
+        border-color: var(--danger);
+      }
+
+      .field__hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .field__error {
+        font-size: 0.85rem;
+        color: var(--danger);
+      }
+
+      @media (max-width: 540px) {
+        .app-shell {
+          padding: 20px 16px;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .controls__group {
+          justify-content: space-between;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <main class="app-shell">
+      <header class="toolbar">
+        <p class="toolbar__title">Friendly match</p>
+        <div class="toolbar__actions">
+          <button type="button" id="newRoundButton" class="button button--ghost">
+            New round
+          </button>
+          <button type="button" id="settingsButton" class="button button--ghost">
+            Settings
+          </button>
+          <button
+            type="button"
+            id="themeToggle"
+            class="button button--ghost button--icon"
+            aria-pressed="false"
+            aria-label="Switch to dark theme"
+            title="Switch to dark theme"
+          >
+            <span class="button__icon" data-theme-icon aria-hidden="true">☀️</span>
+            <span data-theme-text>Light theme</span>
+          </button>
+        </div>
+      </header>
+
+      <section
+        class="scoreboard"
+        id="scoreboard"
+        role="region"
+        aria-label="Player scoreboard"
+      >
+        <article class="scoreboard__player scoreboard__player--x">
+          <span class="scoreboard__mark" aria-hidden="true">X</span>
+          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="X"
+            aria-label="Wins for player X"
+            >0</span
+          >
+        </article>
+        <article class="scoreboard__player scoreboard__player--o">
+          <span class="scoreboard__mark" aria-hidden="true">O</span>
+          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="O"
+            aria-label="Wins for player O"
+            >0</span
+          >
+        </article>
+      </section>
+
+      <section class="status" id="statusMessage" aria-live="polite">
+        Player X (X) to move
+      </section>
+
+      <section
+        class="board"
+        id="board"
+        role="grid"
+        aria-label="Tic Tac Toe board"
+        aria-live="polite"
+      >
+        <button type="button" class="cell" data-cell data-index="0" aria-label="Row 1 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="1" aria-label="Row 1 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="2" aria-label="Row 1 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="3" aria-label="Row 2 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="4" aria-label="Row 2 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="5" aria-label="Row 2 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="6" aria-label="Row 3 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="7" aria-label="Row 3 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="8" aria-label="Row 3 column 3"></button>
+      </section>
+
+      <footer class="controls">
+        <div class="controls__group">
+          <button type="button" id="resetScoresButton" class="button button--ghost">
+            Reset scores
+          </button>
+        </div>
+        <div class="controls__group">
+          <button type="button" id="resetGameButton" class="button">
+            Reset game
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form method="dialog" id="settingsForm" class="modal" novalidate>
+        <header class="modal__header">
+          <h2 id="settingsTitle" class="modal__title">Game settings</h2>
+        </header>
+        <section class="modal__body">
+          <p class="field__hint">
+            Update each player's display name. Leave a field blank to use the default
+            name.
+          </p>
+          <div class="field">
+            <label for="playerXName">Player X name</label>
+            <input
+              type="text"
+              id="playerXName"
+              name="playerX"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player X"
+              aria-describedby="playerXHelp playerXError"
+            />
+            <p id="playerXHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerXError" class="field__error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="field">
+            <label for="playerOName">Player O name</label>
+            <input
+              type="text"
+              id="playerOName"
+              name="playerO"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player O"
+              aria-describedby="playerOHelp playerOError"
+            />
+            <p id="playerOHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerOError" class="field__error" data-error-for="playerO" hidden></p>
+          </div>
+        </section>
+        <footer class="modal__footer">
+          <button type="button" value="cancel" class="button button--ghost" id="settingsCancelButton">
+            Cancel
+          </button>
+          <button type="submit" class="button">Save</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <script src="js/ui/status.js" defer></script>
+    <script src="js/game.js" defer></script>
+    <script src="js/ui/settings.js" defer></script>
+    <script src="js/ui/theme.js" defer></script>
+  </body>
+</html>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,273 @@
+(function () {
+  const WINNING_LINES = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  const STORAGE_KEY = "tictactoe:game-state";
+
+  const nextPlayer = (player) => (player === "X" ? "O" : "X");
+
+  const normaliseBoard = (value) => {
+    if (!Array.isArray(value) || value.length !== 9) {
+      return Array(9).fill(null);
+    }
+
+    return value.map((cell) => (cell === "X" || cell === "O" ? cell : null));
+  };
+
+  const normaliseWinningLine = (value) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const filtered = value
+      .map((index) => (Number.isInteger(index) ? index : null))
+      .filter((index) => index !== null && index >= 0 && index < 9);
+
+    return filtered.length === 3 ? filtered : null;
+  };
+
+  const parseScore = (input) => {
+    const number = Number(input);
+    if (!Number.isFinite(number) || number < 0) {
+      return 0;
+    }
+
+    return Math.trunc(number);
+  };
+
+  const normaliseScores = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    return {
+      X: parseScore(value.X),
+      O: parseScore(value.O),
+    };
+  };
+
+  const readPersistedState = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn("Unable to load saved game state", error);
+      return null;
+    }
+  };
+
+  const writePersistedState = (state) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn("Unable to persist game state", error);
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const cells = Array.from(document.querySelectorAll("[data-cell]"));
+    const newRoundButton = document.getElementById("newRoundButton");
+    const resetScoresButton = document.getElementById("resetScoresButton");
+    const resetGameButton = document.getElementById("resetGameButton");
+    const status = window.uiStatus;
+
+    if (!status) {
+      throw new Error("Status UI has not been initialised");
+    }
+
+    let board = Array(9).fill(null);
+    let currentPlayer = "X";
+    let gameOver = false;
+    let lastWinner = null;
+    let activeWinningLine = null;
+
+    const disableAllCells = () => {
+      cells.forEach((cell) => {
+        cell.setAttribute("aria-disabled", "true");
+      });
+    };
+
+    const clearCell = (cell) => {
+      cell.textContent = "";
+      cell.removeAttribute("data-mark");
+      cell.classList.remove("cell--x", "cell--o", "cell--winner");
+      cell.removeAttribute("aria-disabled");
+    };
+
+    const renderCell = (cell, player) => {
+      cell.textContent = player;
+      cell.dataset.mark = player;
+      cell.classList.remove("cell--x", "cell--o");
+      cell.classList.add(player === "X" ? "cell--x" : "cell--o");
+      cell.setAttribute("aria-disabled", "true");
+    };
+
+    const findWinningLine = (player) =>
+      WINNING_LINES.find((line) => line.every((index) => board[index] === player));
+
+    const highlightWinner = (line) => {
+      activeWinningLine = [...line];
+      line.forEach((index) => {
+        cells[index].classList.add("cell--winner");
+      });
+    };
+
+    const isBoardFull = () => board.every((value) => value !== null);
+
+    const persistState = () => {
+      const state = {
+        board: [...board],
+        currentPlayer,
+        gameOver,
+        winner: lastWinner,
+        winningLine: activeWinningLine ? [...activeWinningLine] : null,
+        scores: status.getScores(),
+      };
+
+      writePersistedState(state);
+    };
+
+    const restoreState = () => {
+      const saved = readPersistedState();
+      if (!saved) {
+        startNewRound();
+        return;
+      }
+
+      board = normaliseBoard(saved.board);
+      currentPlayer = saved.currentPlayer === "O" ? "O" : "X";
+      gameOver = Boolean(saved.gameOver);
+      lastWinner = saved.winner === "X" || saved.winner === "O" ? saved.winner : null;
+      activeWinningLine = normaliseWinningLine(saved.winningLine);
+
+      const savedScores = normaliseScores(saved.scores);
+      if (savedScores) {
+        status.setScores(savedScores);
+      } else {
+        status.resetScores();
+      }
+
+      cells.forEach((cell, index) => {
+        const mark = board[index];
+        if (mark === "X" || mark === "O") {
+          renderCell(cell, mark);
+        } else {
+          clearCell(cell);
+        }
+      });
+
+      if (gameOver) {
+        if (activeWinningLine && activeWinningLine.length === 3) {
+          highlightWinner(activeWinningLine);
+        }
+        disableAllCells();
+        if (lastWinner) {
+          status.announceWin(lastWinner);
+        } else {
+          status.announceDraw();
+        }
+      } else {
+        status.setTurn(currentPlayer);
+      }
+
+      persistState();
+    };
+
+    const startNewRound = () => {
+      board = Array(9).fill(null);
+      gameOver = false;
+      lastWinner = null;
+      activeWinningLine = null;
+      cells.forEach((cell) => clearCell(cell));
+      currentPlayer = "X";
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const resetGame = () => {
+      status.resetScores();
+      startNewRound();
+    };
+
+    const handleCellClick = (event) => {
+      if (gameOver) {
+        return;
+      }
+
+      const cell = event.currentTarget;
+      const index = Number(cell.dataset.index);
+
+      if (board[index]) {
+        return;
+      }
+
+      board[index] = currentPlayer;
+      renderCell(cell, currentPlayer);
+
+      const winningLine = findWinningLine(currentPlayer);
+      if (winningLine) {
+        highlightWinner(winningLine);
+        gameOver = true;
+        lastWinner = currentPlayer;
+        status.announceWin(currentPlayer);
+        status.incrementScore(currentPlayer);
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      if (isBoardFull()) {
+        gameOver = true;
+        lastWinner = null;
+        activeWinningLine = null;
+        status.announceDraw();
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      currentPlayer = nextPlayer(currentPlayer);
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const handleNewRound = () => {
+      startNewRound();
+    };
+
+    const handleResetGame = () => {
+      resetGame();
+    };
+
+    const handleResetScores = () => {
+      status.resetScores();
+      persistState();
+    };
+
+    cells.forEach((cell) => {
+      cell.addEventListener("click", handleCellClick);
+    });
+
+    newRoundButton?.addEventListener("click", handleNewRound);
+    resetGameButton?.addEventListener("click", handleResetGame);
+    resetScoresButton?.addEventListener("click", handleResetScores);
+
+    restoreState();
+  });
+})();

--- a/site/js/ui/theme.js
+++ b/site/js/ui/theme.js
@@ -1,0 +1,93 @@
+(function () {
+  const STORAGE_KEY = "tictactoe:theme";
+  const THEMES = {
+    LIGHT: "light",
+    DARK: "dark",
+  };
+
+  const readStoredTheme = () => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === THEMES.LIGHT || stored === THEMES.DARK) {
+        return stored;
+      }
+      return null;
+    } catch (error) {
+      console.warn("Unable to access stored theme preference", error);
+      return null;
+    }
+  };
+
+  const writeStoredTheme = (theme) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch (error) {
+      console.warn("Unable to persist theme preference", error);
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const root = document.documentElement;
+    const toggleButton = document.getElementById("themeToggle");
+    const iconElement = toggleButton?.querySelector("[data-theme-icon]");
+    const textElement = toggleButton?.querySelector("[data-theme-text]");
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    let storedPreference = readStoredTheme();
+
+    const updateToggleVisuals = (theme) => {
+      if (!toggleButton) {
+        return;
+      }
+
+      const isDark = theme === THEMES.DARK;
+      toggleButton.setAttribute("aria-pressed", String(isDark));
+      const label = isDark ? "Switch to light theme" : "Switch to dark theme";
+      toggleButton.setAttribute("aria-label", label);
+      toggleButton.setAttribute("title", label);
+      if (iconElement) {
+        iconElement.textContent = isDark ? "🌙" : "☀️";
+      }
+      if (textElement) {
+        textElement.textContent = isDark ? "Dark theme" : "Light theme";
+      }
+    };
+
+    const applyTheme = (theme, { persist = true } = {}) => {
+      const nextTheme = theme === THEMES.DARK ? THEMES.DARK : THEMES.LIGHT;
+      root.dataset.theme = nextTheme;
+      root.style.colorScheme = nextTheme;
+      updateToggleVisuals(nextTheme);
+      if (persist) {
+        storedPreference = nextTheme;
+        writeStoredTheme(nextTheme);
+      }
+    };
+
+    const initialTheme = storedPreference
+      ? storedPreference
+      : mediaQuery.matches
+      ? THEMES.DARK
+      : THEMES.LIGHT;
+
+    applyTheme(initialTheme, { persist: false });
+
+    const handleMediaChange = (event) => {
+      if (storedPreference) {
+        return;
+      }
+      applyTheme(event.matches ? THEMES.DARK : THEMES.LIGHT, { persist: false });
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleMediaChange);
+    } else if (mediaQuery.addListener) {
+      mediaQuery.addListener(handleMediaChange);
+    }
+
+    toggleButton?.addEventListener("click", () => {
+      const next = root.dataset.theme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+      applyTheme(next);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- restore the main game page with a toolbar theme toggle, refreshed styling, and accessibility affordances
- persist the selected theme in localStorage while respecting system color-scheme defaults and CSS custom properties
- document how to control the theme toggle and how it interacts with system settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df3a5ab514832894af5712ba7aa6cc