### PR TITLE
feat: sync player names with new state modules

### DIFF
--- a/site/js/state/core.js
+++ b/site/js/state/core.js
@@ -1,0 +1,115 @@
+(function () {
+  const DEFAULT_NAMES = {
+    X: "Player X",
+    O: "Player O",
+  };
+  const NAME_PATTERN =
+    window.coreState?.NAME_PATTERN ??
+    /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+
+  const listeners = new Map();
+  let playerNames = { ...DEFAULT_NAMES };
+
+  const sanitiseName = (value, fallback) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return fallback;
+    }
+    return NAME_PATTERN.test(trimmed) ? trimmed : fallback;
+  };
+
+  const normaliseNames = (nextNames) => ({
+    X: sanitiseName(nextNames?.X ?? "", DEFAULT_NAMES.X),
+    O: sanitiseName(nextNames?.O ?? "", DEFAULT_NAMES.O),
+  });
+
+  const emit = (event, detail) => {
+    const handlers = listeners.get(event);
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(detail);
+        } catch (error) {
+          console.error("coreState listener failed", error);
+        }
+      });
+    }
+
+    if (typeof document !== "undefined" && typeof CustomEvent === "function") {
+      document.dispatchEvent(
+        new CustomEvent(`state:${event}`, {
+          detail,
+        })
+      );
+    }
+  };
+
+  const setPlayerNames = (nextNames, options = {}) => {
+    const { silent = false, source = "core" } = options;
+    const normalised = normaliseNames(nextNames);
+    const changed =
+      normalised.X !== playerNames.X || normalised.O !== playerNames.O;
+
+    playerNames = normalised;
+
+    if (!silent && changed) {
+      emit("players-changed", {
+        names: { ...playerNames },
+        source,
+      });
+    }
+
+    return { ...playerNames };
+  };
+
+  const subscribe = (event, handler) => {
+    if (typeof handler !== "function") {
+      return () => {};
+    }
+
+    if (!listeners.has(event)) {
+      listeners.set(event, new Set());
+    }
+
+    const handlers = listeners.get(event);
+    handlers.add(handler);
+
+    return () => {
+      handlers.delete(handler);
+      if (!handlers.size) {
+        listeners.delete(event);
+      }
+    };
+  };
+
+  const api = {
+    DEFAULT_NAMES: { ...DEFAULT_NAMES },
+    NAME_PATTERN,
+    getPlayerNames() {
+      return { ...playerNames };
+    },
+    setPlayerNames(nextNames, options) {
+      return setPlayerNames(nextNames, options);
+    },
+    hydratePlayerNames(nextNames, options = {}) {
+      const { emitUpdate = true, source = "hydrate" } = options;
+      return setPlayerNames(nextNames, {
+        silent: !emitUpdate,
+        source,
+      });
+    },
+    subscribe(event, handler) {
+      return subscribe(event, handler);
+    },
+  };
+
+  window.coreState = api;
+
+  if (typeof document !== "undefined" && typeof CustomEvent === "function") {
+    document.dispatchEvent(
+      new CustomEvent("core:ready", {
+        detail: { state: api },
+      })
+    );
+  }
+})();

--- a/site/js/state/history.js
+++ b/site/js/state/history.js
@@ -1,0 +1,173 @@
+(function () {
+  const DEFAULT_NAMES = {
+    X: "Player X",
+    O: "Player O",
+  };
+  const NAME_PATTERN =
+    window.coreState?.NAME_PATTERN ??
+    /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+
+  let coreSubscription = null;
+  const listeners = new Map();
+
+  const snapshot = {
+    players: { ...DEFAULT_NAMES },
+  };
+
+  const sanitiseName = (value, fallback) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return fallback;
+    }
+    return NAME_PATTERN.test(trimmed) ? trimmed : fallback;
+  };
+
+  const normaliseNames = (names) => ({
+    X: sanitiseName(names?.X ?? "", DEFAULT_NAMES.X),
+    O: sanitiseName(names?.O ?? "", DEFAULT_NAMES.O),
+  });
+
+  const emit = (event, detail) => {
+    const handlers = listeners.get(event);
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(detail);
+        } catch (error) {
+          console.error("history listener failed", error);
+        }
+      });
+    }
+
+    if (typeof document !== "undefined" && typeof CustomEvent === "function") {
+      document.dispatchEvent(
+        new CustomEvent(`history:${event}`, {
+          detail,
+        })
+      );
+    }
+  };
+
+  const applyPlayerNames = (names, options = {}) => {
+    const { silent = false, source = "history" } = options;
+    const normalised = normaliseNames(names);
+    const changed =
+      normalised.X !== snapshot.players.X || normalised.O !== snapshot.players.O;
+
+    snapshot.players = normalised;
+
+    if (!silent && changed) {
+      emit("players-changed", {
+        names: { ...snapshot.players },
+        source,
+      });
+    }
+
+    return { ...snapshot.players };
+  };
+
+  const subscribe = (event, handler) => {
+    if (typeof handler !== "function") {
+      return () => {};
+    }
+
+    if (!listeners.has(event)) {
+      listeners.set(event, new Set());
+    }
+
+    const handlers = listeners.get(event);
+    handlers.add(handler);
+
+    return () => {
+      handlers.delete(handler);
+      if (!handlers.size) {
+        listeners.delete(event);
+      }
+    };
+  };
+
+  const connectToCoreState = () => {
+    if (coreSubscription || typeof window === "undefined") {
+      return;
+    }
+
+    const core = window.coreState;
+    if (!core) {
+      return;
+    }
+
+    try {
+      applyPlayerNames(core.getPlayerNames?.(), {
+        silent: true,
+        source: "core",
+      });
+    } catch (error) {
+      console.warn("Unable to synchronise player names from core state", error);
+    }
+
+    if (typeof core.subscribe === "function") {
+      coreSubscription = core.subscribe("players-changed", (detail) => {
+        if (!detail || !detail.names) {
+          return;
+        }
+        applyPlayerNames(detail.names, {
+          silent: false,
+          source: detail.source ?? "core",
+        });
+      });
+    }
+  };
+
+  const api = {
+    getPlayers() {
+      return { ...snapshot.players };
+    },
+    setPlayerNames(names, options) {
+      return applyPlayerNames(names, options);
+    },
+    getSharePayload(additional = {}) {
+      return {
+        ...additional,
+        players: { ...snapshot.players },
+      };
+    },
+    getSnapshot() {
+      return {
+        players: { ...snapshot.players },
+      };
+    },
+    subscribe(event, handler) {
+      return subscribe(event, handler);
+    },
+    disconnect() {
+      if (typeof coreSubscription === "function") {
+        coreSubscription();
+      }
+      coreSubscription = null;
+    },
+  };
+
+  window.gameHistory = api;
+
+  if (window.coreState) {
+    connectToCoreState();
+  } else if (typeof document !== "undefined") {
+    document.addEventListener("core:ready", connectToCoreState, {
+      once: true,
+    });
+  }
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("state:players-changed", (event) => {
+      const detail = event?.detail;
+      if (!detail || !detail.names) {
+        return;
+      }
+
+      applyPlayerNames(detail.names, {
+        silent: true,
+        source: detail.source ?? "core",
+      });
+    });
+  }
+})();

--- a/site/js/ui/settings.js
+++ b/site/js/ui/settings.js
@@ -1,14 +1,25 @@
 (function () {
   const STORAGE_KEY = "tictactoe:player-names";
+  const coreDefaults = window.coreState?.DEFAULT_NAMES;
   const DEFAULT_NAMES = {
-    X: "Player X",
-    O: "Player O",
+    X: coreDefaults?.X ?? "Player X",
+    O: coreDefaults?.O ?? "Player O",
   };
-  const NAME_PATTERN = /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+  const NAME_PATTERN =
+    window.coreState?.NAME_PATTERN ??
+    /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+  const INVALID_MESSAGE =
+    "Use letters, numbers, spaces, apostrophes, periods or hyphens only.";
+
+  const isNameValid = (value) =>
+    typeof value === "string" && NAME_PATTERN.test(value);
 
   const sanitiseName = (value, fallback) => {
-    const trimmed = value.trim();
-    return trimmed.length ? trimmed : fallback;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return fallback;
+    }
+    return isNameValid(trimmed) ? trimmed : fallback;
   };
 
   const normaliseNames = (names) => ({
@@ -42,6 +53,9 @@
   };
 
   const dispatchNameUpdate = (names) => {
+    if (typeof document === "undefined" || typeof CustomEvent !== "function") {
+      return;
+    }
     document.dispatchEvent(
       new CustomEvent("settings:players-updated", {
         detail: { names: { ...names } },
@@ -68,35 +82,66 @@
     const trimmed = input.value.trim();
     let message = "";
 
-    if (trimmed && !NAME_PATTERN.test(trimmed)) {
-      message =
-        "Use letters, numbers, spaces, apostrophes, periods or hyphens only.";
+    if (trimmed && !isNameValid(trimmed)) {
+      message = INVALID_MESSAGE;
     }
 
     if (message) {
       input.classList.add("is-invalid");
+      input.setAttribute("aria-invalid", "true");
       input.setCustomValidity(message);
       if (error) {
         error.hidden = false;
+        error.setAttribute("aria-hidden", "false");
         error.textContent = message;
       }
       return false;
     }
 
     input.classList.remove("is-invalid");
+    input.removeAttribute("aria-invalid");
     input.setCustomValidity("");
     if (error) {
       error.hidden = true;
+      error.setAttribute("aria-hidden", "true");
       error.textContent = "";
     }
     return true;
   };
 
-  const attachValidation = (field) => {
+  const attachValidation = (field, { onDirty } = {}) => {
     if (!field?.input) {
       return;
     }
+
+    if (field.error) {
+      field.error.setAttribute("role", "alert");
+      field.error.setAttribute("aria-live", "polite");
+      field.error.setAttribute(
+        "aria-hidden",
+        field.error.hidden ? "true" : "false"
+      );
+      if (field.error.id) {
+        const describedBy = field.input.getAttribute("aria-describedby");
+        if (!describedBy) {
+          field.input.setAttribute("aria-describedby", field.error.id);
+        } else if (!describedBy.split(/\s+/).includes(field.error.id)) {
+          field.input.setAttribute(
+            "aria-describedby",
+            `${describedBy} ${field.error.id}`
+          );
+        }
+      }
+    }
+
     field.input.addEventListener("input", () => {
+      if (typeof onDirty === "function") {
+        onDirty();
+      }
+      validateField(field);
+    });
+
+    field.input.addEventListener("blur", () => {
       validateField(field);
     });
   };
@@ -112,31 +157,123 @@
     }
 
     const fields = getFieldElements(form);
-    attachValidation(fields.X);
-    attachValidation(fields.O);
-
     let currentNames = normaliseNames(readPersistedNames() ?? DEFAULT_NAMES);
+    let isModalOpen = false;
+    let fieldsDirty = false;
+    let suppressExternalUpdate = false;
 
-    const populateForm = () => {
+    const markDirty = () => {
+      fieldsDirty = true;
+    };
+
+    const populateForm = (names = currentNames) => {
       if (fields.X.input) {
-        fields.X.input.value = currentNames.X;
+        fields.X.input.value = names.X;
         validateField(fields.X);
       }
       if (fields.O.input) {
-        fields.O.input.value = currentNames.O;
+        fields.O.input.value = names.O;
         validateField(fields.O);
       }
+      fieldsDirty = false;
     };
 
+    const syncToExternalModules = (names, source = "settings") => {
+      let latest = { ...names };
+
+      const core = window.coreState;
+      if (core && typeof core.setPlayerNames === "function") {
+        suppressExternalUpdate = true;
+        try {
+          const result = core.setPlayerNames(names, { source });
+          if (result && typeof result === "object") {
+            latest = normaliseNames(result);
+          }
+        } catch (error) {
+          console.warn(
+            "Unable to synchronise player names with core state",
+            error
+          );
+        } finally {
+          suppressExternalUpdate = false;
+        }
+      }
+
+      const history = window.gameHistory;
+      if (history && typeof history.setPlayerNames === "function") {
+        try {
+          history.setPlayerNames(latest, { source });
+        } catch (error) {
+          console.warn(
+            "Unable to synchronise player names with history",
+            error
+          );
+        }
+      }
+
+      const share = window.shareLinks;
+      if (share && typeof share.updatePlayerNames === "function") {
+        try {
+          share.updatePlayerNames({ ...latest });
+        } catch (error) {
+          console.warn(
+            "Unable to synchronise player names with share links",
+            error
+          );
+        }
+      }
+
+      return latest;
+    };
+
+    const applyAndPersistNames = (names, options = {}) => {
+      const {
+        persist = true,
+        notify = true,
+        propagate = true,
+        source = "settings",
+        forceFormUpdate = false,
+      } = options;
+
+      const normalised = normaliseNames(names);
+      currentNames = normalised;
+
+      if (persist) {
+        writePersistedNames(normalised);
+      }
+
+      let finalNames = normalised;
+      if (propagate) {
+        finalNames = syncToExternalModules(normalised, source);
+        currentNames = finalNames;
+      }
+
+      if (notify) {
+        dispatchNameUpdate(finalNames);
+      }
+
+      if (forceFormUpdate || !isModalOpen || !fieldsDirty) {
+        populateForm(finalNames);
+      }
+
+      return finalNames;
+    };
+
+    attachValidation(fields.X, { onDirty: markDirty });
+    attachValidation(fields.O, { onDirty: markDirty });
+
     const closeModal = () => {
+      isModalOpen = false;
       if (modal instanceof HTMLDialogElement) {
         modal.close();
       } else {
         modal.setAttribute("open", "false");
       }
+      populateForm();
     };
 
     const openModal = () => {
+      isModalOpen = true;
       populateForm();
       if (modal instanceof HTMLDialogElement) {
         modal.showModal();
@@ -151,18 +288,25 @@
       const isValidO = validateField(fields.O);
 
       if (!isValidX || !isValidO) {
-        form.reportValidity();
+        if (typeof form.reportValidity === "function") {
+          form.reportValidity();
+        }
         return;
       }
 
       const updated = {
-        X: sanitiseName(fields.X.input ? fields.X.input.value : "", DEFAULT_NAMES.X),
-        O: sanitiseName(fields.O.input ? fields.O.input.value : "", DEFAULT_NAMES.O),
+        X: fields.X.input ? fields.X.input.value : "",
+        O: fields.O.input ? fields.O.input.value : "",
       };
 
-      currentNames = updated;
-      writePersistedNames(updated);
-      dispatchNameUpdate(updated);
+      applyAndPersistNames(updated, {
+        source: "settings",
+        propagate: true,
+        notify: true,
+        persist: true,
+        forceFormUpdate: false,
+      });
+
       closeModal();
     };
 
@@ -184,7 +328,51 @@
       });
     }
 
-    populateForm();
-    dispatchNameUpdate(currentNames);
+    document.addEventListener("state:players-changed", (event) => {
+      if (suppressExternalUpdate) {
+        return;
+      }
+      const detail = event?.detail;
+      if (!detail || !detail.names) {
+        return;
+      }
+
+      applyAndPersistNames(detail.names, {
+        source: detail.source ?? "core",
+        propagate: false,
+        notify: true,
+        persist: true,
+        forceFormUpdate: true,
+      });
+    });
+
+    document.addEventListener("history:players-changed", (event) => {
+      if (suppressExternalUpdate) {
+        return;
+      }
+      const detail = event?.detail;
+      if (!detail || !detail.names) {
+        return;
+      }
+      if (detail.source && detail.source !== "history") {
+        return;
+      }
+
+      applyAndPersistNames(detail.names, {
+        source: "history",
+        propagate: true,
+        notify: true,
+        persist: true,
+        forceFormUpdate: true,
+      });
+    });
+
+    applyAndPersistNames(currentNames, {
+      source: "settings:init",
+      propagate: true,
+      notify: true,
+      persist: true,
+      forceFormUpdate: false,
+    });
   });
 })();

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -102,8 +102,39 @@
       applyNames(detail.names);
     });
 
+    document.addEventListener("state:players-changed", (event) => {
+      const detail = event?.detail;
+      if (!detail || !detail.names) {
+        return;
+      }
+      applyNames(detail.names);
+    });
+
+    document.addEventListener("history:players-changed", (event) => {
+      const detail = event?.detail;
+      if (!detail || !detail.names) {
+        return;
+      }
+      if (detail.source && detail.source !== "history") {
+        return;
+      }
+      applyNames(detail.names);
+    });
+
     applyNames(DEFAULT_NAMES);
     updateScoreDisplay();
     refreshStatus();
+
+    const core = window.coreState;
+    if (core && typeof core.getPlayerNames === "function") {
+      try {
+        const names = core.getPlayerNames();
+        if (names) {
+          applyNames(names);
+        }
+      } catch (error) {
+        console.warn("Unable to read player names from core state", error);
+      }
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- add core and history state layers to manage player name data and emit shared events
- sync the settings workflow with the new modules, persist validated names, and surface accessible error messaging
- update the status UI to read from core state/history events so displayed names stay current

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a5d9aa083288eaa8782bf323fcc