### PR TITLE
feat: improve touch target sizing

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -86,11 +86,32 @@ body {
   vertical-align: middle;
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease;
+  min-block-size: 44px;
+  min-inline-size: 44px;
+  min-height: 44px;
+  min-width: 44px;
+  padding: clamp(0.25rem, 1vw, 0.5rem);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .board td:hover {
   background-color: var(--color-border-hover);
   border-color: var(--color-accent);
+}
+
+button,
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="tel"],
+select,
+textarea {
+  min-block-size: 44px;
+  padding-block: 0.625rem;
+  padding-inline: 1rem;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .message {

--- a/site/style.css
+++ b/site/style.css
@@ -45,6 +45,12 @@ a.button {
   text-decoration: none;
   box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  min-block-size: 44px;
+  min-inline-size: 44px;
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 a.button:hover {


### PR DESCRIPTION
## Summary
- expand board cell and form control hit areas to meet the 44px touch target guideline
- add mobile Safari touch responsiveness tweaks for core interactive elements
- ensure the 404 return button also respects new sizing and touch-action rules

## Changes
- enforce minimum inline/block sizing, padding, and touch-action settings on board cells and form-related controls
- apply touch-action and tap highlight adjustments plus minimum sizing for the 404 page CTA button

## Testing
```
Manual - Loaded http://127.0.0.1:4173/ in Chromium desktop
Manual - Loaded http://127.0.0.1:4173/ with Playwright iPhone 13 viewport
Manual - Loaded http://127.0.0.1:4173/ with Playwright Pixel 5 viewport
```

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have updated documentation as needed.
- [x] I have verified that the CI pipeline passes locally or understand existing failures.
- [x] I am ready for this change to be reviewed and merged.

------
https://chatgpt.com/codex/tasks/task_e_68df3a5e9df88328a126b01351489373