### PR TITLE
Add offline awareness banner to Tic Tac Toe UI

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,558 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --surface: #ffffff;
+        --surface-muted: #f3f4f6;
+        --surface-strong: #111827;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-dark: #1d4ed8;
+        --text: #111827;
+        --text-secondary: #4b5563;
+        --danger: #dc2626;
+        --warning-surface: rgba(220, 38, 38, 0.08);
+        --warning-border: rgba(220, 38, 38, 0.35);
+        --warning-hover: rgba(17, 24, 39, 0.05);
+        --warning-text: var(--surface-strong);
+        --warning-icon: var(--danger);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #111827;
+          --surface-muted: #1f2937;
+          --surface-strong: #f9fafb;
+          --border: #374151;
+          --accent: #3b82f6;
+          --accent-dark: #2563eb;
+          --text: #f9fafb;
+          --text-secondary: #d1d5db;
+          --warning-surface: rgba(248, 113, 113, 0.18);
+          --warning-border: rgba(252, 165, 165, 0.45);
+          --warning-hover: rgba(249, 250, 251, 0.1);
+          --warning-text: var(--surface-strong);
+          --warning-icon: #fca5a5;
+        }
+      }
+
+      body {
+        background: var(--surface-muted);
+        color: var(--text);
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 32px 16px 48px;
+        box-sizing: border-box;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+        letter-spacing: -0.015em;
+      }
+
+      .connection-banner {
+        width: min(680px, 100%);
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        border-radius: 12px;
+        border: 1px solid var(--warning-border);
+        background: var(--warning-surface);
+        color: var(--warning-text);
+        padding: 14px 16px;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
+      }
+
+      .connection-banner[hidden] {
+        display: none !important;
+      }
+
+      .connection-banner__content {
+        display: flex;
+        flex: 1;
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .connection-banner__icon {
+        font-size: 1.25rem;
+        line-height: 1;
+        color: var(--warning-icon);
+      }
+
+      .connection-banner__message {
+        margin: 0;
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+
+      .connection-banner__dismiss {
+        margin-left: auto;
+        background: transparent;
+        border: 1px solid currentColor;
+        color: inherit;
+        font-size: 0.9rem;
+        font-weight: 600;
+        padding: 6px 12px;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background 150ms ease, color 150ms ease, border-color 150ms ease,
+          transform 150ms ease;
+        white-space: nowrap;
+      }
+
+      .connection-banner__dismiss:hover {
+        background: var(--warning-hover);
+        transform: translateY(-1px);
+      }
+
+      .connection-banner__dismiss:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .app-shell {
+        width: min(680px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: clamp(20px, 4vw, 32px);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar__title {
+        font-size: clamp(1.25rem, 2vw + 1rem, 1.5rem);
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .toolbar__actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        font: inherit;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 150ms ease, border-color 150ms ease, color 150ms ease,
+          transform 150ms ease;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .button {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .button:hover {
+        background: var(--accent-dark);
+        transform: translateY(-1px);
+      }
+
+      .button--ghost {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .button--ghost:hover {
+        background: rgba(37, 99, 235, 0.12);
+        border-color: var(--accent);
+        color: var(--accent-dark);
+      }
+
+      .scoreboard {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+      }
+
+      .scoreboard__player {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        background: var(--surface-muted);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .scoreboard__mark {
+        font-weight: 700;
+        font-size: 1.125rem;
+        color: var(--accent);
+      }
+
+      .scoreboard__name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .scoreboard__score {
+        font-weight: 700;
+        font-size: 1.35rem;
+        justify-self: end;
+      }
+
+      .status {
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        font-size: 1.05rem;
+        line-height: 1.5;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .cell {
+        aspect-ratio: 1 / 1;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        font-size: clamp(2.75rem, 9vw, 3.75rem);
+        font-weight: 600;
+        background: var(--surface-muted);
+        color: var(--surface-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 150ms ease, background 150ms ease, border-color 150ms ease,
+          color 150ms ease;
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent);
+      }
+
+      .cell[aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+
+      .cell--x {
+        color: var(--accent);
+      }
+
+      .cell--o {
+        color: var(--danger);
+      }
+
+      .cell--winner {
+        background: rgba(59, 130, 246, 0.16);
+        border-color: var(--accent);
+      }
+
+      .controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .controls__group {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+        max-width: min(420px, 90vw);
+      }
+
+      dialog::backdrop {
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .modal__header {
+        padding: 24px 24px 12px;
+      }
+
+      .modal__title {
+        margin: 0;
+        font-size: 1.35rem;
+      }
+
+      .modal__body {
+        padding: 0 24px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .modal__footer {
+        padding: 16px 24px 24px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--border);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .field label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .field input[type="text"] {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        font: inherit;
+        background: var(--surface);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+      }
+
+      .field input[type="text"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .field input[type="text"].is-invalid {
+        border-color: var(--danger);
+      }
+
+      .field__hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .field__error {
+        font-size: 0.85rem;
+        color: var(--danger);
+      }
+
+      @media (max-width: 540px) {
+        .app-shell {
+          padding: 20px 16px;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .controls__group {
+          justify-content: space-between;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tic Tac Toe</h1>
+    <div
+      id="connectionBanner"
+      class="connection-banner"
+      role="status"
+      aria-live="assertive"
+      aria-atomic="true"
+      hidden
+      tabindex="-1"
+    >
+      <div class="connection-banner__content">
+        <span class="connection-banner__icon" aria-hidden="true">⚠️</span>
+        <p id="connectionBannerMessage" class="connection-banner__message">
+          You are offline. Game progress is saved locally until you reconnect.
+        </p>
+      </div>
+      <button
+        type="button"
+        id="connectionBannerDismiss"
+        class="connection-banner__dismiss"
+        aria-label="Dismiss offline status message"
+      >
+        Dismiss
+      </button>
+    </div>
+    <main class="app-shell">
+      <header class="toolbar">
+        <p class="toolbar__title">Friendly match</p>
+        <div class="toolbar__actions">
+          <button type="button" id="newRoundButton" class="button button--ghost">
+            New round
+          </button>
+          <button type="button" id="settingsButton" class="button button--ghost">
+            Settings
+          </button>
+        </div>
+      </header>
+
+      <section
+        class="scoreboard"
+        id="scoreboard"
+        role="region"
+        aria-label="Player scoreboard"
+      >
+        <article class="scoreboard__player scoreboard__player--x">
+          <span class="scoreboard__mark" aria-hidden="true">X</span>
+          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="X"
+            aria-label="Wins for player X"
+            >0</span
+          >
+        </article>
+        <article class="scoreboard__player scoreboard__player--o">
+          <span class="scoreboard__mark" aria-hidden="true">O</span>
+          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <span
+            class="scoreboard__score"
+            data-role="score"
+            data-player="O"
+            aria-label="Wins for player O"
+            >0</span
+          >
+        </article>
+      </section>
+
+      <section class="status" id="statusMessage" aria-live="polite">
+        Player X (X) to move
+      </section>
+
+      <section
+        class="board"
+        id="board"
+        role="grid"
+        aria-label="Tic Tac Toe board"
+        aria-live="polite"
+      >
+        <button type="button" class="cell" data-cell data-index="0" aria-label="Row 1 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="1" aria-label="Row 1 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="2" aria-label="Row 1 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="3" aria-label="Row 2 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="4" aria-label="Row 2 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="5" aria-label="Row 2 column 3"></button>
+        <button type="button" class="cell" data-cell data-index="6" aria-label="Row 3 column 1"></button>
+        <button type="button" class="cell" data-cell data-index="7" aria-label="Row 3 column 2"></button>
+        <button type="button" class="cell" data-cell data-index="8" aria-label="Row 3 column 3"></button>
+      </section>
+
+      <footer class="controls">
+        <div class="controls__group">
+          <button type="button" id="resetScoresButton" class="button button--ghost">
+            Reset scores
+          </button>
+        </div>
+        <div class="controls__group">
+          <button type="button" id="resetGameButton" class="button">
+            Reset game
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <dialog id="settingsModal" aria-labelledby="settingsTitle">
+      <form method="dialog" id="settingsForm" class="modal" novalidate>
+        <header class="modal__header">
+          <h2 id="settingsTitle" class="modal__title">Game settings</h2>
+        </header>
+        <section class="modal__body">
+          <p class="field__hint">
+            Update each player's display name. Leave a field blank to use the default
+            name.
+          </p>
+          <div class="field">
+            <label for="playerXName">Player X name</label>
+            <input
+              type="text"
+              id="playerXName"
+              name="playerX"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player X"
+              aria-describedby="playerXHelp playerXError"
+            />
+            <p id="playerXHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerXError" class="field__error" data-error-for="playerX" hidden></p>
+          </div>
+          <div class="field">
+            <label for="playerOName">Player O name</label>
+            <input
+              type="text"
+              id="playerOName"
+              name="playerO"
+              inputmode="text"
+              autocomplete="name"
+              maxlength="24"
+              placeholder="Player O"
+              aria-describedby="playerOHelp playerOError"
+            />
+            <p id="playerOHelp" class="field__hint">
+              Letters, numbers, spaces, hyphens, apostrophes and periods only (max 24
+              characters).
+            </p>
+            <p id="playerOError" class="field__error" data-error-for="playerO" hidden></p>
+          </div>
+        </section>
+        <footer class="modal__footer">
+          <button type="button" value="cancel" class="button button--ghost" id="settingsCancelButton">
+            Cancel
+          </button>
+          <button type="submit" class="button">Save</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <script src="js/ui/connection.js" defer></script>
+    <script src="js/ui/status.js" defer></script>
+    <script src="js/game.js" defer></script>
+    <script src="js/ui/settings.js" defer></script>
+  </body>
+</html>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -1,0 +1,273 @@
+(function () {
+  const WINNING_LINES = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  const STORAGE_KEY = "tictactoe:game-state";
+
+  const nextPlayer = (player) => (player === "X" ? "O" : "X");
+
+  const normaliseBoard = (value) => {
+    if (!Array.isArray(value) || value.length !== 9) {
+      return Array(9).fill(null);
+    }
+
+    return value.map((cell) => (cell === "X" || cell === "O" ? cell : null));
+  };
+
+  const normaliseWinningLine = (value) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const filtered = value
+      .map((index) => (Number.isInteger(index) ? index : null))
+      .filter((index) => index !== null && index >= 0 && index < 9);
+
+    return filtered.length === 3 ? filtered : null;
+  };
+
+  const parseScore = (input) => {
+    const number = Number(input);
+    if (!Number.isFinite(number) || number < 0) {
+      return 0;
+    }
+
+    return Math.trunc(number);
+  };
+
+  const normaliseScores = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    return {
+      X: parseScore(value.X),
+      O: parseScore(value.O),
+    };
+  };
+
+  const readPersistedState = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn("Unable to load saved game state", error);
+      return null;
+    }
+  };
+
+  const writePersistedState = (state) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn("Unable to persist game state", error);
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const cells = Array.from(document.querySelectorAll("[data-cell]"));
+    const newRoundButton = document.getElementById("newRoundButton");
+    const resetScoresButton = document.getElementById("resetScoresButton");
+    const resetGameButton = document.getElementById("resetGameButton");
+    const status = window.uiStatus;
+
+    if (!status) {
+      throw new Error("Status UI has not been initialised");
+    }
+
+    let board = Array(9).fill(null);
+    let currentPlayer = "X";
+    let gameOver = false;
+    let lastWinner = null;
+    let activeWinningLine = null;
+
+    const disableAllCells = () => {
+      cells.forEach((cell) => {
+        cell.setAttribute("aria-disabled", "true");
+      });
+    };
+
+    const clearCell = (cell) => {
+      cell.textContent = "";
+      cell.removeAttribute("data-mark");
+      cell.classList.remove("cell--x", "cell--o", "cell--winner");
+      cell.removeAttribute("aria-disabled");
+    };
+
+    const renderCell = (cell, player) => {
+      cell.textContent = player;
+      cell.dataset.mark = player;
+      cell.classList.remove("cell--x", "cell--o");
+      cell.classList.add(player === "X" ? "cell--x" : "cell--o");
+      cell.setAttribute("aria-disabled", "true");
+    };
+
+    const findWinningLine = (player) =>
+      WINNING_LINES.find((line) => line.every((index) => board[index] === player));
+
+    const highlightWinner = (line) => {
+      activeWinningLine = [...line];
+      line.forEach((index) => {
+        cells[index].classList.add("cell--winner");
+      });
+    };
+
+    const isBoardFull = () => board.every((value) => value !== null);
+
+    const persistState = () => {
+      const state = {
+        board: [...board],
+        currentPlayer,
+        gameOver,
+        winner: lastWinner,
+        winningLine: activeWinningLine ? [...activeWinningLine] : null,
+        scores: status.getScores(),
+      };
+
+      writePersistedState(state);
+    };
+
+    const restoreState = () => {
+      const saved = readPersistedState();
+      if (!saved) {
+        startNewRound();
+        return;
+      }
+
+      board = normaliseBoard(saved.board);
+      currentPlayer = saved.currentPlayer === "O" ? "O" : "X";
+      gameOver = Boolean(saved.gameOver);
+      lastWinner = saved.winner === "X" || saved.winner === "O" ? saved.winner : null;
+      activeWinningLine = normaliseWinningLine(saved.winningLine);
+
+      const savedScores = normaliseScores(saved.scores);
+      if (savedScores) {
+        status.setScores(savedScores);
+      } else {
+        status.resetScores();
+      }
+
+      cells.forEach((cell, index) => {
+        const mark = board[index];
+        if (mark === "X" || mark === "O") {
+          renderCell(cell, mark);
+        } else {
+          clearCell(cell);
+        }
+      });
+
+      if (gameOver) {
+        if (activeWinningLine && activeWinningLine.length === 3) {
+          highlightWinner(activeWinningLine);
+        }
+        disableAllCells();
+        if (lastWinner) {
+          status.announceWin(lastWinner);
+        } else {
+          status.announceDraw();
+        }
+      } else {
+        status.setTurn(currentPlayer);
+      }
+
+      persistState();
+    };
+
+    const startNewRound = () => {
+      board = Array(9).fill(null);
+      gameOver = false;
+      lastWinner = null;
+      activeWinningLine = null;
+      cells.forEach((cell) => clearCell(cell));
+      currentPlayer = "X";
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const resetGame = () => {
+      status.resetScores();
+      startNewRound();
+    };
+
+    const handleCellClick = (event) => {
+      if (gameOver) {
+        return;
+      }
+
+      const cell = event.currentTarget;
+      const index = Number(cell.dataset.index);
+
+      if (board[index]) {
+        return;
+      }
+
+      board[index] = currentPlayer;
+      renderCell(cell, currentPlayer);
+
+      const winningLine = findWinningLine(currentPlayer);
+      if (winningLine) {
+        highlightWinner(winningLine);
+        gameOver = true;
+        lastWinner = currentPlayer;
+        status.announceWin(currentPlayer);
+        status.incrementScore(currentPlayer);
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      if (isBoardFull()) {
+        gameOver = true;
+        lastWinner = null;
+        activeWinningLine = null;
+        status.announceDraw();
+        disableAllCells();
+        persistState();
+        return;
+      }
+
+      currentPlayer = nextPlayer(currentPlayer);
+      status.setTurn(currentPlayer);
+      persistState();
+    };
+
+    const handleNewRound = () => {
+      startNewRound();
+    };
+
+    const handleResetGame = () => {
+      resetGame();
+    };
+
+    const handleResetScores = () => {
+      status.resetScores();
+      persistState();
+    };
+
+    cells.forEach((cell) => {
+      cell.addEventListener("click", handleCellClick);
+    });
+
+    newRoundButton?.addEventListener("click", handleNewRound);
+    resetGameButton?.addEventListener("click", handleResetGame);
+    resetScoresButton?.addEventListener("click", handleResetScores);
+
+    restoreState();
+  });
+})();

--- a/site/js/ui/connection.js
+++ b/site/js/ui/connection.js
@@ -1,0 +1,182 @@
+(function () {
+  const OFFLINE_MESSAGE =
+    "You are offline. Game progress is saved locally until you reconnect.";
+  const ONLINE_MESSAGE =
+    "Connection restored. Online-only features are available again.";
+
+  const onlineHandlers = new Set();
+  let isOnline = navigator.onLine;
+  let banner = null;
+  let messageElement = null;
+  let dismissButton = null;
+  let userDismissed = false;
+  let hasInitialised = false;
+
+  const setDocumentNetworkState = () => {
+    const root = document.documentElement;
+    if (root) {
+      root.setAttribute("data-network-state", isOnline ? "online" : "offline");
+    }
+  };
+
+  const dispatchStatusEvent = () => {
+    document.dispatchEvent(
+      new CustomEvent("app:network-status", {
+        detail: { online: isOnline },
+      })
+    );
+  };
+
+  const runOnlineHandlers = () => {
+    onlineHandlers.forEach((handler) => {
+      try {
+        handler();
+      } catch (error) {
+        console.error("Error running online handler", error);
+      }
+    });
+  };
+
+  const hideBanner = () => {
+    if (!banner) {
+      return;
+    }
+    banner.hidden = true;
+    banner.setAttribute("aria-hidden", "true");
+  };
+
+  const showBanner = ({ focus = false } = {}) => {
+    if (!banner || userDismissed) {
+      return;
+    }
+    banner.hidden = false;
+    banner.setAttribute("aria-hidden", "false");
+    if (focus) {
+      requestAnimationFrame(() => {
+        try {
+          banner.focus();
+        } catch (error) {
+          console.warn("Unable to focus offline banner", error);
+        }
+      });
+    }
+  };
+
+  const updateBannerVisibility = ({ focus = false } = {}) => {
+    if (!banner) {
+      return;
+    }
+
+    if (!isOnline && !userDismissed) {
+      showBanner({ focus });
+    } else {
+      hideBanner();
+    }
+  };
+
+  const setMessage = (text) => {
+    if (messageElement) {
+      messageElement.textContent = text;
+    }
+  };
+
+  const setOnlineState = (nextState, options = {}) => {
+    const focus = Boolean(options.focus);
+    const previousState = isOnline;
+    isOnline = Boolean(nextState);
+
+    if (isOnline) {
+      if (!previousState) {
+        userDismissed = false;
+      }
+      updateBannerVisibility({ focus: false });
+      if (!previousState) {
+        runOnlineHandlers();
+      }
+    } else {
+      if (previousState) {
+        userDismissed = false;
+      }
+      updateBannerVisibility({ focus });
+    }
+
+    setDocumentNetworkState();
+    if (previousState !== isOnline) {
+      dispatchStatusEvent();
+    }
+  };
+
+  const handleDismiss = (event) => {
+    if (event) {
+      event.preventDefault();
+    }
+    userDismissed = true;
+    hideBanner();
+    if (dismissButton) {
+      dismissButton.blur();
+    }
+  };
+
+  const handleOnline = () => {
+    setMessage(ONLINE_MESSAGE);
+    setOnlineState(true);
+  };
+
+  const handleOffline = () => {
+    setMessage(OFFLINE_MESSAGE);
+    setOnlineState(false, { focus: hasInitialised });
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    banner = document.getElementById("connectionBanner");
+    messageElement = document.getElementById("connectionBannerMessage");
+    dismissButton = document.getElementById("connectionBannerDismiss");
+
+    if (banner) {
+      banner.setAttribute("aria-hidden", banner.hidden ? "true" : "false");
+    }
+
+    if (dismissButton) {
+      dismissButton.addEventListener("click", handleDismiss);
+    }
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    setDocumentNetworkState();
+    if (isOnline) {
+      setMessage(ONLINE_MESSAGE);
+      hideBanner();
+      runOnlineHandlers();
+    } else {
+      setMessage(OFFLINE_MESSAGE);
+      updateBannerVisibility({ focus: false });
+    }
+    dispatchStatusEvent();
+    hasInitialised = true;
+  });
+
+  window.appNetwork = {
+    isOnline: () => isOnline,
+    onOnline(handler, options = {}) {
+      if (typeof handler !== "function") {
+        return () => {};
+      }
+
+      const immediate = options.immediate !== false;
+      onlineHandlers.add(handler);
+
+      if (isOnline && immediate) {
+        try {
+          handler();
+        } catch (error) {
+          console.error("Error running online handler", error);
+        }
+      }
+
+      return () => {
+        onlineHandlers.delete(handler);
+      };
+    },
+  };
+})();


### PR DESCRIPTION
## Summary
- restore the Tic Tac Toe page markup and styling with an offline status banner at the top of the layout
- add a connection controller that surfaces app:network-status events, gates network-dependent hooks, and manages the banner’s visibility
- reinstate the saved-game UI logic so the refreshed page stays fully interactive alongside the new offline messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3a61d27c8328a06f0e966fbb01f3