### PR TITLE
Add security policy for static site

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+This project is a static TicTacToe site deployed to GitHub Pages. There is no
+backend service or secret material to access. Security reports should therefore
+focus on vulnerabilities in the static assets, build tooling, or repository
+configuration.
+
+## Scope
+
+* In scope: client-side vulnerabilities in the published site, supply-chain
+  risks in the build pipeline, or misconfigurations affecting GitHub Pages
+  hosting.
+* Out of scope: server-side exploits, data exfiltration attacks, or other
+  findings that require backend access or secrets (none exist for this project).
+
+## Reporting a Vulnerability
+
+Please report potential vulnerabilities by opening a new security advisory via
+GitHub's Security tab for this repository. If you prefer email, contact the
+maintainers at `security@example.com`.
+
+Provide as much detail as possible, including reproduction steps, the affected
+URL or asset, and any supporting screenshots or logs.
+
+## Response Timeline
+
+* Initial acknowledgement: within 3 business days.
+* Triage update with next steps: within 7 business days of acknowledgement.
+* Fix or mitigation ETA: communicated once the issue is confirmed, typically
+  within 30 days depending on severity and complexity.
+
+We will keep you updated throughout the process and credit reporters in release
+notes if desired.
+
+## Coordinated Disclosure
+
+Once a fix or mitigation is available, we prefer coordinated disclosure. We
+may request that you withhold public disclosure for up to 30 days after a patch
+is released to allow users time to update.
+
+## Safe Harbor
+
+We will not pursue legal action for good-faith research that respects this
+policy, avoids privacy violations, and does not disrupt the live site.


### PR DESCRIPTION
## What changed
- add SECURITY.md describing how to report vulnerabilities in the static GitHub Pages deployment
- document scope, timelines, and coordinated disclosure expectations for the project

## Why
- provide a clear security disclosure policy recognized by GitHub

## Screenshots
- n/a

## Testing notes
- [ ] Unit tests added or updated
- [ ] E2E ran green in CI

## A11y checklist
- [ ] Focus order verified
- [ ] ARIA roles and labels present
- [ ] Color contrast validated

------
https://chatgpt.com/codex/tasks/task_e_68df4e9937ac8328af13ea857d0713f9