### PR TITLE
Add Lighthouse CI budgets and documentation

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,25 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          configPath: ./lighthouserc.json
+          budgetsFile: ./lighthouse-budgets.json
+          uploadArtifacts: true
+          temporaryPublicStorage: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 artifacts/
 dist/
+.lighthouseci/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Tic Tac Toe is a tiny web project that demonstrates the full lifecycle of buildi
 - **Unit tests:** `npm run test`
 - **Continuous integration:** See the workflows in `.github/workflows/` for Pages deployment.
 
+## Performance monitoring
+
+- **Budgets:** Performance budgets for Largest Contentful Paint, Total Blocking Time, and script size live in [`lighthouse-budgets.json`](lighthouse-budgets.json). Update these values when agreed targets change so CI reflects the latest expectations.
+- **Automation:** The [Lighthouse CI workflow](.github/workflows/lighthouse.yml) runs on every push to `main` and for pull requests. It serves the static `site/` directory locally using [`lighthouserc.json`](lighthouserc.json) and fails if a budget is exceeded.
+- **Interpreting results:** Download the `lighthouse-report` artifact from the workflow run, extract it, and open `lighthouse-report.html` (or the run-specific HTML file) in a browser to review metric deltas, opportunities, and budgets. The artifact also includes the `manifest.json` file for comparing scores across runs.
+
 ## Deployment Overview
 
 1. Build the project locally with `npm run build` to generate optimized assets.

--- a/lighthouse-budgets.json
+++ b/lighthouse-budgets.json
@@ -1,0 +1,31 @@
+[
+  {
+    "path": "/*",
+    "resourceSizes": [
+      {
+        "resourceType": "script",
+        "budget": 50
+      },
+      {
+        "resourceType": "total",
+        "budget": 200
+      }
+    ],
+    "resourceCounts": [
+      {
+        "resourceType": "third-party",
+        "budget": 0
+      }
+    ],
+    "timings": [
+      {
+        "metric": "largest-contentful-paint",
+        "budget": 2500
+      },
+      {
+        "metric": "total-blocking-time",
+        "budget": 200
+      }
+    ]
+  }
+]

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,22 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "staticDistDir": "site",
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": ".lighthouseci"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Lighthouse performance budgets and CI config for the static site
- run Lighthouse in GitHub Actions with budget enforcement and stored reports
- document the workflow usage and ignore the generated .lighthouseci directory

## Testing
- not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68df4e95d0fc8328b06e376e2c014a20