### PR TITLE
Update sitemap and robots metadata

### DIFF
--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://alex-unnippillil.github.io/tictactoe/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>/</loc>
+    <loc>https://alex-unnippillil.github.io/tictactoe/</loc>
+    <lastmod>2025-10-02T22:02:16-04:00</lastmod>
+  </url>
+  <url>
+    <loc>https://alex-unnippillil.github.io/tictactoe/404.html</loc>
+    <lastmod>2025-10-02T22:01:18-04:00</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- update the sitemap to reference the canonical GitHub Pages URLs and include last-modified timestamps
- expose the sitemap via robots.txt while explicitly allowing crawlers

## Testing
- python site/sitemap.xml well-formed check
- python robots.txt parse and sitemap detection


------
https://chatgpt.com/codex/tasks/task_e_68df4e95d5448328b17dcb948623334e