### PR TITLE
fix: load game dependencies before controller init

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -147,8 +147,9 @@
     <script src="js/core/history.js" defer></script>
     <script src="js/state/core.js" defer></script>
     <script src="js/state/history.js" defer></script>
-    <script src="js/ui/status.js" defer></script>
+    <script src="js/ai/minimax.js" defer></script>
     <script src="js/game.js" defer></script>
+    <script src="js/ui/status.js" defer></script>
     <script src="js/ui/settings.js" defer></script>
   </body>
 </html>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -512,6 +512,7 @@
     const controller = createGameController();
     if (controller) {
       global.tictactoeGame = controller;
+      global.GameController = controller;
     }
   });
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- ensure the HTML loads the core and AI scripts before the main game controller
- expose the game controller on `window.GameController` to support runtime checks

## Testing
- npm test
- npm run serve (manual verification via browser console)


------
https://chatgpt.com/codex/tasks/task_e_68df570fd9c4832897104dc28714a13f