### PR TITLE
Ensure GitHub Pages loads the Tic Tac Toe app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,84 +10,45 @@ Visit the published site on GitHub Pages: **https://alex-unnippillil.github.io/t
 
 ![Screenshot of the Tic Tac Toe board](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
 
-## Static site assets
+## Overview
 
-The `site/` directory contains supplemental static files such as `robots.txt` and `sitemap.xml`. Include this folder when publishing or deploying the site so search engines can access these resources.
-## License
+Tic Tac Toe is a static web application that showcases a polished, accessible take on the classic game. The implementation uses vanilla JavaScript and persists game progress and player names in `localStorage` so you can leave and return without losing your history.
 
-This project is licensed under the [MIT License](LICENSE).
-# Tic Tac Toe
+## Getting Started
 
-![Screenshot of the Tic Tac Toe board](https://github.com/Alex-Unnippillil/tictactoe/assets/24538548/15b4eda8-43c2-4f28-8fd5-593098a90799)
+> **Prerequisites:** Node.js 20+
 
-## Project Purpose
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the local web server and open the printed URL:
+   ```bash
+   npm start
+   ```
+   The root page redirects straight to the interactive game located in the `site/` directory.
+3. Stop the server at any time with `Ctrl+C`.
 
-Tic Tac Toe is a tiny web project that demonstrates the full lifecycle of building, testing, and deploying a simple interactive game. It is intentionally lightweight, making it ideal for experimenting with static site hosting on GitHub Pages or for showcasing basic DOM manipulation with vanilla JavaScript.
-
-## Quick Start
-
-1. Install dependencies with `npm install`.
-2. Launch the local development server with `npm run dev` and open the provided URL in your browser.
-3. Make changes to `index.html`; the development server will automatically reload the page.
-
-> **Prerequisites:** Node.js 18+ and npm 9+.
-
-## Community guidelines
-
-We are committed to fostering a welcoming and inclusive environment. Please
-review our [Code of Conduct](CODE_OF_CONDUCT.md) for expectations on community
-behavior and reporting. For details on how to get involved, see the
-[contribution guide](CONTRIBUTING.md).
-
-## Scripts
+## Available scripts
 
 | Command | Description |
 | --- | --- |
-| `npm run dev` | Starts the local development server for iterative work.
-| `npm run build` | Produces the production-ready static assets.
-| `npm run test` | Executes the automated test suite.
-| `npm run lint` | Runs linting to ensure code quality and consistency.
-| `npm run deploy` | Publishes the `dist/` output to GitHub Pages.
+| `npm start` | Launches a static server that hosts the game from the `site/` directory. |
+| `npm run serve` | Alias for `npm start` kept for compatibility. |
+| `npm test` | Runs the Node.js test suite found in `tests/unit`. |
+| `npm run lint` | Placeholder command – update it with your preferred linting setup. |
+| `npm run e2e` | Placeholder command reserved for future end-to-end tests. |
 
-## Local Development
+## Project structure
 
-- **Start a hot-reloading server:** `npm run dev`
-- **Run linters while developing:** `npm run lint`
-- **Format and lint before committing:** `npm run lint && npm run test`
+- `index.html` – lightweight redirect that ensures GitHub Pages loads the interactive site instead of the repository README.
+- `site/` – source of truth for the production-ready HTML, CSS, JavaScript, and supplemental static assets (`robots.txt`, `sitemap.xml`, etc.).
+- `tests/` – unit tests for the underlying game logic.
 
-## Testing
+## Community guidelines
 
-- **Unit tests:** `npm run test`
-- **Continuous integration:** See the workflows in `.github/workflows/` for Pages deployment.
-
-## Lighthouse audits
-
-A dedicated [Lighthouse CI workflow](.github/workflows/lighthouse.yml) runs `npx lhci autorun` against the deployed GitHub Pages site at `https://alex-unnippillil.github.io/tictactoe/`. The job uploads the HTML report as an artifact named **`lighthouse-report`** so you can review the latest accessibility, performance, best practices, and SEO scores for the production build.
-
-To inspect the results for any run:
-
-1. Open the workflow run in GitHub Actions.
-2. Scroll to the **Artifacts** section and download **`lighthouse-report`**.
-3. Extract the archive locally and open `report.html` in your browser to view the full Lighthouse dashboard.
-
-## Deployment Overview
-
-1. Build the project locally with `npm run build` to generate optimized assets.
-2. Preview the static bundle by serving the `dist/` directory locally if desired.
-3. Deploy the latest build using `npm run deploy`, which pushes the generated content to the GitHub Pages branch.
-4. GitHub Actions workflows automate deployment to ensure the published site stays in sync with the main branch.
-
-## Changelog
-
-Review the [CHANGELOG](CHANGELOG.md) for a curated list of notable updates to the project. Release announcements should link back to the same changelog entry to keep documentation and notes aligned.
-
-## Architecture Overview
-
-The project is a static HTML application comprised of:
-
-- `index.html` containing the markup, inline styles, and JavaScript that power the entire game experience.
-- No external build system is required; however, npm scripts provide scaffolding for future enhancements such as bundling or testing frameworks.
+We are committed to fostering a welcoming and inclusive environment. Please review our [Code of Conduct](CODE_OF_CONDUCT.md) for expectations on community behavior and reporting. For details on how to get involved, see the [contribution guide](CONTRIBUTING.md).
 
 ## License
 
-SPDX-License-Identifier: MIT
+This project is licensed under the [MIT License](LICENSE).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tic Tac Toe</title>
+    <meta http-equiv="refresh" content="0; url=site/" />
+    <link rel="canonical" href="site/" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: Canvas;
+        color: CanvasText;
+        text-align: center;
+        padding: 2rem;
+      }
+      a {
+        color: inherit;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting to Tic Tac Toe…</h1>
+      <p>
+        If you are not redirected automatically, follow this
+        <a href="site/">link to the game</a>.
+      </p>
+    </main>
+    <script>
+      window.requestAnimationFrame(function () {
+        try {
+          window.location.replace('site/');
+        } catch (error) {
+          window.location.href = 'site/';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=20"
   },
   "scripts": {
+    "start": "npm run serve",
     "lint": "echo \"No lint script configured\"",
     "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",

--- a/site/index.html
+++ b/site/index.html
@@ -205,7 +205,6 @@
     <script src="js/state/history.js" defer></script>
     <script src="js/ai/minimax.js" defer></script>
     <script src="js/game.js" defer></script>
-    <script src="js/ui/status.js" defer></script>
     <script src="js/ui/settings.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a lightweight root index that redirects visitors straight to the interactive site assets
- remove the duplicate status script include from the game shell and expose an npm start command for serving the app
- refresh the README so local setup instructions match the current scripts and file layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df58e2b90483289c4ef074f3ee47b2