### PR TITLE
feat: redesign scoreboard glass layout

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -9,6 +9,19 @@
   font: inherit;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 html:focus-within {
   scroll-behavior: smooth;
 }
@@ -221,37 +234,279 @@ button:focus-visible {
 }
 
 .scoreboard {
+  position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
+  grid-template-columns: 1fr;
+  gap: 0;
+  width: 100%;
+  padding: clamp(12px, 3vw, 24px);
+  border-radius: 24px;
+  background: linear-gradient(
+    140deg,
+    rgba(59, 130, 246, 0.16),
+    rgba(236, 72, 153, 0.12)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.scoreboard::before,
+.scoreboard::after {
+  content: "";
+  position: absolute;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.scoreboard::before {
+  inset: -35% 12% 58%;
+  background: radial-gradient(
+    circle at top,
+    rgba(255, 255, 255, 0.45),
+    transparent 65%
+  );
+  opacity: 0.55;
+}
+
+.scoreboard::after {
+  inset: 0;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+@media (min-width: 560px) {
+  .scoreboard {
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
+    gap: clamp(18px, 4vw, 28px);
+    justify-content: center;
+    align-content: center;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .scoreboard {
+    border-color: rgba(148, 163, 184, 0.32);
+    background: linear-gradient(
+      145deg,
+      rgba(37, 99, 235, 0.22),
+      rgba(236, 72, 153, 0.18),
+      rgba(17, 24, 39, 0.72)
+    );
+  }
+
+  .scoreboard::after {
+    border-color: rgba(148, 163, 184, 0.24);
+  }
 }
 
 .scoreboard__player {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 16px;
-  background: var(--surface-muted);
+  --player-mark-color: var(--accent);
+  --player-highlight: rgba(59, 130, 246, 0.42);
+  --player-glow: rgba(59, 130, 246, 0.68);
+  --player-mark-glow: rgba(59, 130, 246, 0.58);
+  position: relative;
+  z-index: 0;
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 12px;
+  gap: clamp(12px, 3vw, 18px);
+  padding: clamp(16px, 3.5vw, 24px) clamp(18px, 5vw, 28px);
+  border-radius: 20px;
+  color: var(--surface-strong);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.74),
+    rgba(148, 163, 184, 0.18)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  box-shadow:
+    0 18px 36px rgba(15, 23, 42, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 12px var(--player-highlight);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
+  isolation: isolate;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease;
+}
+
+.scoreboard__player::before,
+.scoreboard__player::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.scoreboard__player::before {
+  inset: -42% 10% 56%;
+  background: radial-gradient(
+    circle at top,
+    rgba(255, 255, 255, 0.6),
+    transparent 70%
+  );
+  opacity: 0.55;
+  transition: opacity 220ms ease;
+}
+
+.scoreboard__player::after {
+  inset: -20%;
+  z-index: -1;
+  background: radial-gradient(
+    circle at center,
+    var(--player-glow),
+    rgba(37, 99, 235, 0)
+  );
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  .scoreboard__player {
+    background: linear-gradient(
+      135deg,
+      rgba(30, 41, 59, 0.82),
+      rgba(15, 23, 42, 0.6)
+    );
+    border-color: rgba(148, 163, 184, 0.34);
+    box-shadow:
+      0 20px 40px rgba(2, 6, 23, 0.6),
+      0 0 0 1px rgba(148, 163, 184, 0.12),
+      0 0 12px var(--player-highlight);
+  }
+}
+
+.scoreboard__player:hover {
+  transform: translateY(-2px);
+}
+
+.scoreboard__player--active {
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.88),
+      rgba(148, 163, 184, 0.22)
+    ),
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.12),
+      rgba(255, 255, 255, 0)
+    );
+  border-color: rgba(255, 255, 255, 0.54);
+  box-shadow:
+    0 24px 52px rgba(15, 23, 42, 0.28),
+    0 0 0 2px rgba(255, 255, 255, 0.45),
+    0 0 28px var(--player-glow);
+  transform: translateY(-4px);
+}
+
+.scoreboard__player--active::before {
+  opacity: 0.75;
+}
+
+.scoreboard__player--active::after {
+  opacity: 0.82;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .scoreboard__player--active::after {
+    animation: scoreboard-glow 3s ease-in-out infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scoreboard__player,
+  .scoreboard__player::after {
+    transition: none;
+  }
+}
+
+.scoreboard__player--x {
+  --player-mark-color: var(--accent);
+  --player-highlight: rgba(59, 130, 246, 0.42);
+  --player-glow: rgba(59, 130, 246, 0.66);
+  --player-mark-glow: rgba(59, 130, 246, 0.58);
+}
+
+.scoreboard__player--o {
+  --player-mark-color: var(--danger);
+  --player-highlight: rgba(244, 63, 94, 0.45);
+  --player-glow: rgba(244, 63, 94, 0.62);
+  --player-mark-glow: rgba(244, 63, 94, 0.62);
+}
+
+.scoreboard__mark,
+.scoreboard__name,
+.scoreboard__score {
+  position: relative;
+  z-index: 1;
 }
 
 .scoreboard__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(44px, 6vw, 52px);
+  height: clamp(44px, 6vw, 52px);
+  border-radius: 14px;
   font-weight: 700;
-  font-size: 1.125rem;
-  color: var(--accent);
+  font-size: clamp(1rem, 2.4vw, 1.25rem);
+  color: var(--player-mark-color);
+  background: linear-gradient(
+    135deg,
+    var(--player-mark-glow),
+    rgba(255, 255, 255, 0.08)
+  );
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.35),
+    0 0 18px var(--player-mark-glow);
+  text-shadow: 0 0 12px var(--player-mark-glow);
 }
 
 .scoreboard__name {
   font-weight: 600;
-  font-size: 1.05rem;
+  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+  letter-spacing: 0.01em;
 }
 
 .scoreboard__score {
-  font-weight: 700;
-  font-size: 1.35rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
   justify-self: end;
+}
+
+.scoreboard__score-value {
+  font-weight: 700;
+  font-size: clamp(1.4rem, 3vw, 1.75rem);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  text-shadow: 0 0 14px var(--player-mark-glow);
+}
+
+@keyframes scoreboard-glow {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: scale(0.95);
+  }
+
+  50% {
+    opacity: 0.95;
+    transform: scale(1.05);
+  }
 }
 
 .status {

--- a/site/index.html
+++ b/site/index.html
@@ -27,27 +27,35 @@
         role="region"
         aria-label="Player scoreboard"
       >
-        <article class="scoreboard__player scoreboard__player--x">
+        <article class="scoreboard__player scoreboard__player--x" data-player="X">
           <span class="scoreboard__mark" aria-hidden="true">X</span>
           <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
-          <span
-            class="scoreboard__score"
-            data-role="score"
-            data-player="X"
-            aria-label="Wins for player X"
-            >0</span
-          >
+          <span class="scoreboard__score" data-player="X">
+            <span id="score-label-x" class="visually-hidden">Wins for player X</span>
+            <span
+              class="scoreboard__score-value"
+              data-role="score"
+              data-player="X"
+              aria-labelledby="score-label-x"
+              aria-live="polite"
+              >0</span
+            >
+          </span>
         </article>
-        <article class="scoreboard__player scoreboard__player--o">
+        <article class="scoreboard__player scoreboard__player--o" data-player="O">
           <span class="scoreboard__mark" aria-hidden="true">O</span>
           <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
-          <span
-            class="scoreboard__score"
-            data-role="score"
-            data-player="O"
-            aria-label="Wins for player O"
-            >0</span
-          >
+          <span class="scoreboard__score" data-player="O">
+            <span id="score-label-o" class="visually-hidden">Wins for player O</span>
+            <span
+              class="scoreboard__score-value"
+              data-role="score"
+              data-player="O"
+              aria-labelledby="score-label-o"
+              aria-live="polite"
+              >0</span
+            >
+          </span>
         </article>
       </section>
 

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -14,8 +14,20 @@
       X: document.querySelector('[data-role="score"][data-player="X"]'),
       O: document.querySelector('[data-role="score"][data-player="O"]'),
     };
+    const playerCards = {
+      X: document.querySelector('.scoreboard__player[data-player="X"]'),
+      O: document.querySelector('.scoreboard__player[data-player="O"]'),
+    };
 
-    if (!statusMessage || !nameElements.X || !nameElements.O) {
+    if (
+      !statusMessage ||
+      !nameElements.X ||
+      !nameElements.O ||
+      !scoreElements.X ||
+      !scoreElements.O ||
+      !playerCards.X ||
+      !playerCards.O
+    ) {
       throw new Error("Unable to initialise status UI; required elements are missing.");
     }
 
@@ -56,20 +68,31 @@
       scoreElements.O.textContent = String(scores.O);
     };
 
+    const setActivePlayerCard = (player) => {
+      (/** @type {("X"|"O")[]} */ (["X", "O"]))
+        .filter((id) => playerCards[id])
+        .forEach((id) => {
+          playerCards[id].classList.toggle("scoreboard__player--active", id === player);
+        });
+    };
+
     const api = {
       setTurn(player) {
         currentPlayer = player;
         statusState = "turn";
         refreshStatus();
+        setActivePlayerCard(player);
       },
       announceWin(player) {
         currentPlayer = player;
         statusState = "win";
         refreshStatus();
+        setActivePlayerCard(player);
       },
       announceDraw() {
         statusState = "draw";
         refreshStatus();
+        setActivePlayerCard(null);
       },
       incrementScore(player) {
         scores[player] += 1;
@@ -141,6 +164,7 @@
     applyNames(DEFAULT_NAMES);
     updateScoreDisplay();
     refreshStatus();
+    setActivePlayerCard(currentPlayer);
 
     const core = window.coreState;
     if (core && typeof core.getPlayerNames === "function") {


### PR DESCRIPTION
## Summary
- restyled the scoreboard container with a layered glass layout that centers on large screens and stacks tightly on mobile
- refreshed player cards with neon-inspired gradients, depth effects, and an active state pulse that honours reduced motion preferences
- updated the score markup and status UI logic for accessible labels while letting scripts toggle the new active modifier

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df877da2b8832897ef8426a986b1b3