### PR TITLE
feat: add hero banner for game page

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -149,6 +149,115 @@ body.page--game {
   overflow-x: hidden;
 }
 
+.hero {
+  position: relative;
+  width: min(960px, 100%);
+  border-radius: clamp(1.75rem, 4vw, 2.75rem);
+  overflow: hidden;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  isolation: isolate;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero__surface {
+  position: relative;
+  width: 100%;
+  border-radius: inherit;
+  background-color: var(--glass-surface-fallback);
+  background-image: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.2),
+      rgba(255, 255, 255, 0)
+    ),
+    linear-gradient(160deg, rgba(148, 163, 184, 0.5), rgba(99, 102, 241, 0.2));
+  border: 1px solid transparent;
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+
+.hero__surface::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.3), transparent 60%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.hero__glow {
+  position: absolute;
+  inset: auto;
+  width: clamp(10rem, 28vw, 18rem);
+  height: clamp(10rem, 32vw, 20rem);
+  border-radius: 999px;
+  filter: blur(45px);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.hero__glow--primary {
+  background: radial-gradient(circle, var(--glow-strong), transparent 70%);
+  top: -25%;
+  left: -10%;
+}
+
+.hero__glow--secondary {
+  background: radial-gradient(circle, var(--glow-accent), transparent 75%);
+  bottom: -30%;
+  right: -8%;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: clamp(1.5rem, 3.5vw, 3rem);
+}
+
+.hero__logo {
+  flex: none;
+  width: clamp(4.5rem, 10vw, 6rem);
+  aspect-ratio: 1;
+  border-radius: 28%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, rgba(59, 130, 246, 0.3), rgba(14, 165, 233, 0.1));
+  box-shadow: inset 0 1px 0 var(--glass-highlight), 0 18px 42px rgba(15, 23, 42, 0.25);
+}
+
+.hero__logo-mark {
+  width: 70%;
+  height: 70%;
+}
+
+.hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.35rem, 1.2vw, 0.75rem);
+  color: var(--text);
+  max-width: 36ch;
+}
+
+.hero__title {
+  font-size: clamp(2.25rem, 5vw, 3.25rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.hero__tagline {
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
 body.page--game::before,
 body.page--game::after {
   content: "";
@@ -175,6 +284,32 @@ body.page--game::after {
   bottom: clamp(-8rem, -6vw, -3rem);
   right: clamp(-12rem, -8vw, -4rem);
   animation: glow-drift 32s ease-in-out infinite alternate-reverse;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: clamp(1.35rem, 5vw, 2rem);
+  }
+
+  .hero__content {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .hero__logo {
+    width: clamp(3.75rem, 18vw, 4.75rem);
+    box-shadow: inset 0 1px 0 var(--glass-highlight), 0 12px 28px rgba(15, 23, 42, 0.18);
+  }
+
+  .hero__tagline {
+    max-width: 28ch;
+    margin-inline: auto;
+  }
+
+  .hero__glow {
+    opacity: 0.55;
+    filter: blur(35px);
+  }
 }
 
 body.page--error {

--- a/site/index.html
+++ b/site/index.html
@@ -7,7 +7,71 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body class="page page--game">
-    <h1>Tic Tac Toe</h1>
+    <header class="hero" role="banner">
+      <div class="hero__surface">
+        <span class="hero__glow hero__glow--primary" aria-hidden="true"></span>
+        <span class="hero__glow hero__glow--secondary" aria-hidden="true"></span>
+        <div class="hero__content">
+          <div class="hero__logo" aria-hidden="true">
+            <svg
+              class="hero__logo-mark"
+              width="96"
+              height="96"
+              viewBox="0 0 96 96"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              focusable="false"
+            >
+              <rect
+                x="12"
+                y="12"
+                width="72"
+                height="72"
+                rx="22"
+                fill="url(#heroGradient)"
+                opacity="0.92"
+              />
+              <path
+                d="M34 34L62 62M34 62L62 34"
+                stroke="white"
+                stroke-width="6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                opacity="0.85"
+              />
+              <circle
+                cx="48"
+                cy="48"
+                r="16.5"
+                stroke="white"
+                stroke-width="5"
+                opacity="0.7"
+              />
+              <defs>
+                <linearGradient
+                  id="heroGradient"
+                  x1="24"
+                  y1="16"
+                  x2="72"
+                  y2="80"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stop-color="#38BDF8" />
+                  <stop offset="0.5" stop-color="#6366F1" />
+                  <stop offset="1" stop-color="#8B5CF6" />
+                </linearGradient>
+              </defs>
+            </svg>
+          </div>
+          <div class="hero__text">
+            <h1 class="hero__title">Tic Tac Toe</h1>
+            <p class="hero__tagline">
+              Strategize, react, and celebrate each match on a polished glass board.
+            </p>
+          </div>
+        </div>
+      </div>
+    </header>
     <main class="app-shell" role="application" aria-label="Tic Tac Toe">
       <header class="toolbar">
         <p class="toolbar__title">


### PR DESCRIPTION
## Summary
- add a structured hero banner with SVG logomark, heading, and tagline above the game shell
- create glass-inspired hero styling with layered glow accents that match the existing aesthetic
- adjust responsive behavior so the hero stacks cleanly on mobile with softened lighting effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df8fc367888328b2a941152d8759d3