### PR TITLE
feat: add fluid typography scale tokens

### DIFF
--- a/docs/typography-scale.md
+++ b/docs/typography-scale.md
@@ -1,0 +1,27 @@
+# Typography scale
+
+The Tic Tac Toe UI relies on a fluid, modular scale so typography adapts smoothly between small and large viewports. Tokens are defined in `site/css/style.css` under the `:root` selector using `clamp()` to interpolate between minimum and maximum sizes.
+
+## Font size tokens
+
+| Token | Clamp expression | Primary use |
+| --- | --- | --- |
+| `--font-size-100` | `clamp(0.78rem, 0.12vw + 0.74rem, 0.86rem)` | Microcopy, legal text |
+| `--font-size-200` | `clamp(0.88rem, 0.18vw + 0.82rem, 0.98rem)` | Captions and helper text |
+| `--font-size-300` | `clamp(1rem, 0.25vw + 0.9rem, 1.125rem)` | Body copy (default on `<body>`) |
+| `--font-size-400` | `clamp(1.15rem, 0.35vw + 1rem, 1.35rem)` | Emphasised body text, subtitles |
+| `--font-size-500` | `clamp(1.3rem, 0.5vw + 1.05rem, 1.8rem)` | Section titles, toolbar titles |
+| `--font-size-600` | `clamp(1.6rem, 0.75vw + 1.25rem, 2.2rem)` | Secondary page headings |
+| `--font-size-700` | `clamp(1.95rem, 1.05vw + 1.5rem, 2.6rem)` | Primary page headings |
+
+### Usage guidelines
+
+- Prefer the tokens over hard-coded `rem` or `px` values for new components so typography stays consistent.
+- Larger breakpoints are intentionally capped to preserve hierarchy and avoid runaway scaling on very wide screens.
+- When a component needs a value between two tokens, consider adjusting layout spacing or introducing a modifier class before adding a new token.
+
+## Spacing tokens
+
+To keep rhythm between components, the same `:root` block also defines fluid spacing tokens (`--space-3xs` through `--space-3xl`). Pair typography and spacing tokens together (for example, `--font-size-400` with `--space-md`) for predictable vertical rhythm.
+
+For questions or adjustments, update the token definitions first and then refactor component styles rather than overriding them locally.

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -37,8 +37,34 @@ body {
   margin: 0;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
+  font-size: var(--font-size-300);
   background: var(--surface, #ffffff);
   color: var(--text, #111827);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-weight: 700;
+  line-height: 1.1;
+  text-wrap: balance;
+}
+
+h1 {
+  font-size: var(--font-size-700);
+}
+
+h2 {
+  font-size: var(--font-size-600);
+}
+
+h3 {
+  font-size: var(--font-size-500);
 }
 
 img,
@@ -68,6 +94,24 @@ select {
   --text: #111827;
   --text-secondary: #4b5563;
   --danger: #dc2626;
+  /* Fluid typography scale (major third) */
+  --font-size-100: clamp(0.78rem, 0.12vw + 0.74rem, 0.86rem);
+  --font-size-200: clamp(0.88rem, 0.18vw + 0.82rem, 0.98rem);
+  --font-size-300: clamp(1rem, 0.25vw + 0.9rem, 1.125rem);
+  --font-size-400: clamp(1.15rem, 0.35vw + 1rem, 1.35rem);
+  --font-size-500: clamp(1.3rem, 0.5vw + 1.05rem, 1.8rem);
+  --font-size-600: clamp(1.6rem, 0.75vw + 1.25rem, 2.2rem);
+  --font-size-700: clamp(1.95rem, 1.05vw + 1.5rem, 2.6rem);
+  /* Fluid spacing scale (1.5 ratio) */
+  --space-3xs: clamp(0.125rem, 0.16vw + 0.09rem, 0.25rem);
+  --space-2xs: clamp(0.25rem, 0.2vw + 0.18rem, 0.5rem);
+  --space-xs: clamp(0.5rem, 0.3vw + 0.35rem, 0.75rem);
+  --space-sm: clamp(0.75rem, 0.4vw + 0.5rem, 1rem);
+  --space-md: clamp(1rem, 0.5vw + 0.75rem, 1.5rem);
+  --space-lg: clamp(1.5rem, 0.8vw + 1.1rem, 2rem);
+  --space-xl: clamp(2rem, 1vw + 1.4rem, 2.75rem);
+  --space-2xl: clamp(2.5rem, 1.2vw + 1.8rem, 3.5rem);
+  --space-3xl: clamp(3rem, 1.6vw + 2.2rem, 4.5rem);
   --page-gradient-base: radial-gradient(
       circle at 20% 20%,
       rgba(59, 130, 246, 0.18),
@@ -449,7 +493,7 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2xs);
-  font-size: clamp(1.1rem, 2vw + 1rem, 1.85rem);
+  font-size: var(--font-size-500);
   font-weight: 700;
   color: var(--text);
   letter-spacing: -0.015em;
@@ -781,16 +825,16 @@ button:focus-visible {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-md);
   border-radius: 999px;
-  padding: 18px 28px 18px 24px;
+  padding: var(--space-md) var(--space-xl) var(--space-md) var(--space-lg);
   background: linear-gradient(
     140deg,
     var(--glass-surface),
     var(--glass-surface-strong)
   );
   border: 1px solid var(--glass-border);
-  font-size: 1.1rem;
+  font-size: var(--font-size-400);
   line-height: 1.5;
   font-weight: 600;
   color: var(--text);
@@ -1029,8 +1073,8 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 18px 20px;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   border-radius: 24px;
   background: linear-gradient(135deg, var(--glass-surface), var(--glass-surface-strong));
   border: 1px solid var(--glass-border);
@@ -1055,8 +1099,8 @@ button:focus-visible {
 .controls__group {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 12px;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.12);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- introduce a fluid modular typography and spacing scale with `clamp()` tokens in the design system
- refactor the body, global headings, toolbar title, status pill, and control bar to consume the new tokens
- document the font scale guidance for contributors in `docs/typography-scale.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8fc3808883288c5bda98a2833cab