### PR TITLE
feat: animate scoreboard updates

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -762,6 +762,59 @@ button:focus-visible {
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
   text-shadow: 0 0 14px var(--player-mark-glow);
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.scoreboard__value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2ch;
+  padding: 2px 6px;
+  border-radius: 8px;
+  transition:
+    background-color 360ms ease-out,
+    color 360ms ease-out,
+    box-shadow 360ms ease-out;
+  transform-origin: center bottom;
+  will-change: transform, opacity;
+}
+
+.scoreboard__value--updating {
+  animation: scoreboard-value-rise 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  background-color: var(--player-highlight);
+  box-shadow: 0 0 18px var(--player-glow);
+}
+
+@keyframes scoreboard-value-rise {
+  0% {
+    transform: translateY(35%) scale(0.92);
+    opacity: 0;
+  }
+
+  55% {
+    transform: translateY(-10%) scale(1.08);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scoreboard__value {
+    transition: background-color 260ms ease-out, color 260ms ease-out;
+  }
+
+  .scoreboard__value--updating {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
 }
 
 @keyframes scoreboard-glow {

--- a/site/index.html
+++ b/site/index.html
@@ -45,12 +45,11 @@
             <span id="score-label-x" class="visually-hidden">Wins for player X</span>
             <span
               class="scoreboard__score-value"
-              data-role="score"
-              data-player="X"
               aria-labelledby="score-label-x"
               aria-live="polite"
-              >0</span
             >
+              <span class="scoreboard__value" data-role="score" data-player="X">0</span>
+            </span>
           </span>
         </article>
         <article class="scoreboard__player scoreboard__player--o" data-player="O">
@@ -60,12 +59,11 @@
             <span id="score-label-o" class="visually-hidden">Wins for player O</span>
             <span
               class="scoreboard__score-value"
-              data-role="score"
-              data-player="O"
               aria-labelledby="score-label-o"
               aria-live="polite"
-              >0</span
             >
+              <span class="scoreboard__value" data-role="score" data-player="O">0</span>
+            </span>
           </span>
         </article>
       </section>

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -6,6 +6,7 @@
 
   document.addEventListener("DOMContentLoaded", () => {
     const statusMessage = document.getElementById("statusMessage");
+    const players = /** @type {const} */ (["X", "O"]);
     const nameElements = {
       X: document.querySelector('[data-role="name"][data-player="X"]'),
       O: document.querySelector('[data-role="name"][data-player="O"]'),
@@ -30,6 +31,26 @@
     ) {
       throw new Error("Unable to initialise status UI; required elements are missing.");
     }
+
+    players
+      .map((player) => scoreElements[player])
+      .filter((element) => element)
+      .forEach((element) => {
+        element.addEventListener("animationend", (event) => {
+          if (event.target === element) {
+            element.classList.remove("scoreboard__value--updating");
+          }
+        });
+        element.addEventListener("transitionend", (event) => {
+          if (
+            event.target === element &&
+            (event.propertyName === "background-color" ||
+              event.propertyName === "color")
+          ) {
+            element.classList.remove("scoreboard__value--updating");
+          }
+        });
+      });
 
     let playerNames = { ...DEFAULT_NAMES };
     let scores = { X: 0, O: 0 };
@@ -74,12 +95,27 @@
     };
 
     const updateScoreDisplay = () => {
-      scoreElements.X.textContent = String(scores.X);
-      scoreElements.O.textContent = String(scores.O);
+      players.forEach((player) => {
+        const element = scoreElements[player];
+        if (!element) {
+          return;
+        }
+
+        const nextValue = String(scores[player]);
+        if (element.textContent === nextValue) {
+          return;
+        }
+
+        element.textContent = nextValue;
+        element.classList.remove("scoreboard__value--updating");
+        // eslint-disable-next-line no-unused-expressions -- Force reflow to restart animation
+        void element.offsetWidth;
+        element.classList.add("scoreboard__value--updating");
+      });
     };
 
     const setActivePlayerCard = (player) => {
-      (/** @type {("X"|"O")[]} */ (["X", "O"]))
+      players
         .filter((id) => playerCards[id])
         .forEach((id) => {
           playerCards[id].classList.toggle("scoreboard__player--active", id === player);


### PR DESCRIPTION
## Summary
- wrap scoreboard scores in a nested element so animations can target the numeric value
- add scoreboard update animation styles with reduced-motion fallback
- trigger the animation when score values change in the status UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fc43bec8328957942c59f3a2b08