### PR TITLE
Animate board reset transitions with reduced-motion support

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -909,6 +909,40 @@ button:focus-visible {
   opacity: calc(var(--cell-reflection-opacity) * 0.75);
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .board {
+    transition: opacity 240ms ease, transform 240ms ease, filter 280ms ease;
+    will-change: transform, opacity, filter;
+  }
+
+  .board--transitioning {
+    opacity: 0;
+    transform: scale(0.96);
+    filter: blur(14px);
+  }
+
+  .board--transitioning .cell {
+    pointer-events: none;
+  }
+
+  .cell {
+    transition: transform 180ms ease, background 180ms ease, border-color 180ms ease,
+      color 180ms ease, box-shadow 220ms ease, opacity 220ms ease, filter 260ms ease;
+  }
+
+  .cell--resetting {
+    opacity: 0;
+    transform: scale(0.88);
+    filter: blur(6px);
+    will-change: transform, opacity, filter;
+  }
+
+  .cell--resetting::before,
+  .cell--resetting::after {
+    opacity: 0;
+  }
+}
+
 .cell:hover {
   transform: translateY(-2px);
   border-color: rgba(59, 130, 246, 0.65);


### PR DESCRIPTION
## Summary
- add CSS transition states for the board and cells that respect prefers-reduced-motion
- coordinate board reset animations in game.js with focus preservation and aria-live timing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fc60c488328a11544660eeaa232