### PR TITLE
feat: add glass confirmation sheet for reset flows

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1361,6 +1361,147 @@ dialog.is-closing::backdrop {
   color: var(--danger);
 }
 
+.confirm-sheet-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.25rem, 4vw, 2.75rem);
+  z-index: 1200;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.confirm-sheet-root[hidden] {
+  display: none;
+}
+
+.confirm-sheet-root[data-open='true'] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.confirm-sheet-layer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.25rem, 4vw, 2.75rem);
+}
+
+.confirm-sheet-layer__backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 100% at 10% 10%, rgba(59, 130, 246, 0.22), transparent),
+    radial-gradient(120% 100% at 90% 15%, rgba(147, 197, 253, 0.2), transparent),
+    color-mix(in srgb, var(--surface-muted) 40%, rgba(15, 23, 42, 0.65));
+  opacity: 0.92;
+  pointer-events: auto;
+  backdrop-filter: blur(calc(var(--glass-blur) * 0.55));
+  -webkit-backdrop-filter: blur(calc(var(--glass-blur) * 0.55));
+  transition: opacity 240ms ease;
+}
+
+.confirm-sheet {
+  position: relative;
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 1.4vw + 0.8rem, 1.5rem);
+  padding: clamp(1.5rem, 2.8vw, 2.25rem) clamp(1.35rem, 2.6vw, 2.1rem);
+  border-radius: clamp(1.25rem, 3vw, 1.75rem);
+  background: var(--glass-surface);
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    var(--glass-shadow),
+    inset 0 1px 0 var(--glass-highlight);
+  color: var(--text);
+  backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+  overflow: hidden;
+  z-index: 1;
+}
+
+.confirm-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.12), transparent 55%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.confirm-sheet__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.confirm-sheet__title {
+  font-size: clamp(1.2rem, 0.9vw + 1rem, 1.45rem);
+  font-weight: 650;
+}
+
+.confirm-sheet__body {
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 0.3vw + 0.95rem, 1.05rem);
+  line-height: 1.6;
+}
+
+.confirm-sheet__message {
+  margin: 0;
+}
+
+.confirm-sheet__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: clamp(0.65rem, 1.2vw, 0.9rem);
+  flex-wrap: wrap;
+}
+
+.confirm-sheet__actions .button {
+  min-width: min(9.5rem, 100%);
+}
+
+@supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+  .confirm-sheet {
+    background: var(--glass-surface-fallback);
+  }
+}
+
+@media (max-width: 640px) {
+  .confirm-sheet-layer {
+    align-items: flex-end;
+    padding: clamp(1rem, 5vw, 2.25rem) clamp(0.85rem, 4.5vw, 2.1rem);
+  }
+
+  .confirm-sheet-layer__backdrop {
+    opacity: 0.88;
+  }
+
+  .confirm-sheet {
+    width: 100%;
+    border-radius: clamp(1.5rem, 7vw, 2rem) clamp(1.5rem, 7vw, 2rem) 0 0;
+    padding: clamp(1.35rem, 5vw, 1.85rem) clamp(1.1rem, 4.5vw, 1.75rem)
+      clamp(1.6rem, 6vw, 2.1rem);
+    box-shadow:
+      0 -8px 20px rgba(15, 23, 42, 0.18),
+      inset 0 1px 0 var(--glass-highlight);
+  }
+
+  .confirm-sheet__actions {
+    justify-content: stretch;
+  }
+
+  .confirm-sheet__actions .button {
+    flex: 1 1 auto;
+  }
+}
+
 @media (max-width: 600px) {
   .app-shell {
     padding: 20px 16px;

--- a/site/index.html
+++ b/site/index.html
@@ -172,6 +172,56 @@
       </div>
     </main>
 
+    <div
+      id="confirmationRoot"
+      class="confirm-sheet-root"
+      hidden
+      aria-hidden="true"
+    ></div>
+
+    <template id="confirmationSheetTemplate">
+      <div class="confirm-sheet-layer" data-confirmation-container>
+        <div
+          class="confirm-sheet-layer__backdrop"
+          data-confirmation-backdrop
+        ></div>
+        <section
+          class="confirm-sheet"
+          role="dialog"
+          aria-modal="true"
+          tabindex="-1"
+          data-confirmation-sheet
+        >
+          <header class="confirm-sheet__header">
+            <h2 class="confirm-sheet__title" data-confirmation-title>
+              Confirm action
+            </h2>
+          </header>
+          <div class="confirm-sheet__body">
+            <p class="confirm-sheet__message" data-confirmation-message>
+              Are you sure you want to continue?
+            </p>
+          </div>
+          <footer class="confirm-sheet__actions">
+            <button
+              type="button"
+              class="button button--ghost"
+              data-confirmation-cancel
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="button"
+              data-confirmation-confirm
+            >
+              Confirm
+            </button>
+          </footer>
+        </section>
+      </div>
+    </template>
+
     <dialog id="settingsModal" aria-labelledby="settingsTitle">
       <form method="dialog" id="settingsForm" class="modal" novalidate>
         <header class="modal__header">

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -162,6 +162,8 @@
     const resetGameButton = document.getElementById('resetGameButton');
     const resetScoresButton = document.getElementById('resetScoresButton');
     const newRoundButton = document.getElementById('newRoundButton');
+    const confirmationRoot = document.getElementById('confirmationRoot');
+    const confirmationTemplate = document.getElementById('confirmationSheetTemplate');
 
     let scores = readStoredScores();
     let board = Array(9).fill(null);
@@ -194,6 +196,214 @@
     const clearPersistedGameState = () => {
       safeLocalStorage.remove(GAME_STORAGE_KEY);
     };
+
+    const showConfirmationSheet = (options = {}) => {
+      const {
+        title = 'Confirm action',
+        message = 'Are you sure you want to continue?',
+        confirmLabel = 'Confirm',
+        cancelLabel = 'Cancel',
+      } = options;
+
+      const doc = typeof document !== 'undefined' ? document : null;
+
+      const useNativeConfirm = () => {
+        if (typeof global.confirm === 'function') {
+          return global.confirm(message || title);
+        }
+        return true;
+      };
+
+      if (!confirmationRoot || !confirmationTemplate) {
+        return Promise.resolve(useNativeConfirm());
+      }
+
+      return new Promise((resolve) => {
+        const fragment = confirmationTemplate.content
+          ? confirmationTemplate.content.cloneNode(true)
+          : null;
+
+        if (!fragment) {
+          resolve(useNativeConfirm());
+          return;
+        }
+
+        const container = fragment.querySelector('[data-confirmation-container]');
+        const sheet = fragment.querySelector('[data-confirmation-sheet]');
+        const titleElement = fragment.querySelector('[data-confirmation-title]');
+        const messageElement = fragment.querySelector('[data-confirmation-message]');
+        const confirmButton = fragment.querySelector('[data-confirmation-confirm]');
+        const cancelButton = fragment.querySelector('[data-confirmation-cancel]');
+        const backdrop = fragment.querySelector('[data-confirmation-backdrop]');
+
+        if (!container || !sheet || !confirmButton || !cancelButton || !backdrop) {
+          resolve(useNativeConfirm());
+          return;
+        }
+
+        const idSuffix = Date.now().toString(36);
+        const titleId = `confirm-sheet-title-${idSuffix}`;
+        const messageId = `confirm-sheet-message-${idSuffix}`;
+
+        titleElement.id = titleId;
+        titleElement.textContent = title;
+        messageElement.id = messageId;
+        messageElement.textContent = message;
+        sheet.setAttribute('aria-labelledby', titleId);
+        sheet.setAttribute('aria-describedby', messageId);
+
+        confirmButton.textContent = confirmLabel;
+        cancelButton.textContent = cancelLabel;
+
+        const focusableSelectors =
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+        const getFocusableElements = () =>
+          Array.from(sheet.querySelectorAll(focusableSelectors)).filter((element) => {
+            if (element.disabled) {
+              return false;
+            }
+            const ariaHidden = element.getAttribute('aria-hidden');
+            return ariaHidden !== 'true' && ariaHidden !== '1';
+          });
+
+        const previouslyFocusedElement =
+          doc && doc.activeElement instanceof HTMLElement
+            ? doc.activeElement
+            : null;
+        const previousBodyOverflow = doc && doc.body && doc.body.style
+          ? doc.body.style.overflow
+          : '';
+
+        let isSettled = false;
+
+        const cleanup = () => {
+          container.removeEventListener('keydown', handleKeyDown);
+          backdrop.removeEventListener('click', handleBackdropClick);
+          confirmButton.removeEventListener('click', handleConfirm);
+          cancelButton.removeEventListener('click', handleCancel);
+          sheet.removeEventListener('click', stopPropagation);
+          sheet.removeEventListener('keydown', handleKeyDown);
+
+          if (container.isConnected) {
+            container.remove();
+          }
+
+          if (!confirmationRoot.hasChildNodes()) {
+            confirmationRoot.dataset.open = 'false';
+            confirmationRoot.setAttribute('aria-hidden', 'true');
+            confirmationRoot.hidden = true;
+          }
+
+          if (doc && doc.body) {
+            doc.body.style.overflow = previousBodyOverflow;
+          }
+
+          if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+            previouslyFocusedElement.focus();
+          }
+        };
+
+        const close = (result) => {
+          if (isSettled) {
+            return;
+          }
+          isSettled = true;
+          cleanup();
+          resolve(result);
+        };
+
+        const handleKeyDown = (event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            close(false);
+            return;
+          }
+
+          if (event.key !== 'Tab') {
+            return;
+          }
+
+          const focusable = getFocusableElements();
+          if (!focusable.length) {
+            event.preventDefault();
+            sheet.focus();
+            return;
+          }
+
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          const active = doc ? doc.activeElement : null;
+
+          if (event.shiftKey) {
+            if (active === first || !sheet.contains(active)) {
+              event.preventDefault();
+              last.focus();
+            }
+          } else if (active === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        };
+
+        const handleBackdropClick = (event) => {
+          if (event.target === backdrop) {
+            event.preventDefault();
+            close(false);
+          }
+        };
+
+        const handleConfirm = (event) => {
+          event.preventDefault();
+          close(true);
+        };
+
+        const handleCancel = (event) => {
+          event.preventDefault();
+          close(false);
+        };
+
+        const stopPropagation = (event) => {
+          event.stopPropagation();
+        };
+
+        confirmationRoot.hidden = false;
+        confirmationRoot.setAttribute('aria-hidden', 'false');
+        confirmationRoot.dataset.open = 'true';
+        confirmationRoot.appendChild(container);
+
+        if (doc && doc.body) {
+          doc.body.style.overflow = 'hidden';
+        }
+
+        container.addEventListener('keydown', handleKeyDown);
+        sheet.addEventListener('keydown', handleKeyDown);
+        sheet.addEventListener('click', stopPropagation);
+        backdrop.addEventListener('click', handleBackdropClick);
+        confirmButton.addEventListener('click', handleConfirm);
+        cancelButton.addEventListener('click', handleCancel);
+
+        const focusInitialElement = () => {
+          const focusable = getFocusableElements();
+          if (focusable.length) {
+            focusable[0].focus();
+          } else {
+            sheet.focus();
+          }
+        };
+
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(focusInitialElement);
+        } else {
+          setTimeout(focusInitialElement, 0);
+        }
+      });
+    };
+
+    const promptConfirmation = (message, overrides = {}) =>
+      showConfirmationSheet({
+        message,
+        ...overrides,
+      });
 
     const setCellDisabled = (cell, disabled) => {
       cell.disabled = disabled;
@@ -412,11 +622,11 @@
       });
     };
 
-    const confirmReset = (message) => {
-      if (!board.some((cell) => cell) || typeof global.confirm !== 'function') {
-        return true;
+    const confirmReset = (message, overrides = {}) => {
+      if (!board.some((cell) => cell)) {
+        return Promise.resolve(true);
       }
-      return global.confirm(message);
+      return promptConfirmation(message, overrides);
     };
 
     const resetScores = () => {
@@ -440,8 +650,15 @@
       });
 
       if (newRoundButton) {
-        newRoundButton.addEventListener('click', () => {
-          if (!isRoundOver && !confirmReset('Start a new round and clear the current board?')) {
+        newRoundButton.addEventListener('click', async () => {
+          if (
+            !isRoundOver &&
+            !(await confirmReset('Start a new round and clear the current board?', {
+              title: 'Start new round',
+              confirmLabel: 'Start new round',
+              cancelLabel: 'Keep playing',
+            }))
+          ) {
             return;
           }
           startNewRound();
@@ -449,8 +666,13 @@
       }
 
       if (resetGameButton) {
-        resetGameButton.addEventListener('click', () => {
-          if (!confirmReset('Reset the game, clearing the board and scores?')) {
+        resetGameButton.addEventListener('click', async () => {
+          const proceed = await confirmReset('Reset the game, clearing the board and scores?', {
+            title: 'Reset game',
+            confirmLabel: 'Reset everything',
+            cancelLabel: 'Cancel',
+          });
+          if (!proceed) {
             return;
           }
           resetGame();
@@ -458,15 +680,17 @@
       }
 
       if (resetScoresButton) {
-        resetScoresButton.addEventListener('click', () => {
+        resetScoresButton.addEventListener('click', async () => {
           if (!scores[PLAYER_X] && !scores[PLAYER_O]) {
             return;
           }
-          if (typeof global.confirm === 'function') {
-            const proceed = global.confirm('Reset the scoreboard?');
-            if (!proceed) {
-              return;
-            }
+          const proceed = await promptConfirmation('Reset the scoreboard?', {
+            title: 'Reset scores',
+            confirmLabel: 'Reset scores',
+            cancelLabel: 'Keep scores',
+          });
+          if (!proceed) {
+            return;
           }
           resetScores();
           persistGameState();


### PR DESCRIPTION
## Summary
- add a reusable confirmation sheet template to the page for custom prompts
- style the sheet with the glass aesthetic and responsive layout
- replace native confirms with a promise-based helper that traps focus and reuses the sheet

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fc6e0208328bafed9d66971d4e1