### PR TITLE
feat: add configurable scoreboard avatars with glass styling

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -580,9 +580,9 @@ button:focus-visible {
   position: relative;
   z-index: 0;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
-  gap: clamp(12px, 3vw, 18px);
+  gap: clamp(10px, 2.5vw, 18px);
   padding: clamp(16px, 3.5vw, 24px) clamp(18px, 5vw, 28px);
   border-radius: 20px;
   color: var(--surface-strong);
@@ -714,11 +714,231 @@ button:focus-visible {
   --player-mark-glow: rgba(244, 63, 94, 0.62);
 }
 
+.scoreboard__avatar,
 .scoreboard__mark,
 .scoreboard__name,
 .scoreboard__score {
   position: relative;
   z-index: 1;
+}
+
+.scoreboard__avatar {
+  --avatar-size: clamp(52px, 7vw, 68px);
+  --avatar-border: rgba(255, 255, 255, 0.55);
+  --avatar-border-dark: rgba(148, 163, 184, 0.45);
+  --avatar-highlight: rgba(255, 255, 255, 0.75);
+  --avatar-shadow: rgba(15, 23, 42, 0.26);
+  --avatar-hue: 220;
+  --avatar-saturation: 72%;
+  --avatar-lightness: 62%;
+  display: grid;
+  place-items: center;
+  width: var(--avatar-size);
+  aspect-ratio: 1;
+  border-radius: clamp(18px, 4vw, 24px);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(148, 163, 184, 0.2));
+  border: 1px solid var(--avatar-border);
+  box-shadow:
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.48),
+    inset 0 -22px 34px rgba(255, 255, 255, 0.22),
+    0 18px 34px rgba(15, 23, 42, 0.24),
+    0 0 26px var(--player-highlight);
+  overflow: hidden;
+  isolation: isolate;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.scoreboard__avatar::before,
+.scoreboard__avatar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.scoreboard__avatar::before {
+  background:
+    radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.85), transparent 60%),
+    radial-gradient(circle at 75% 80%, rgba(255, 255, 255, 0.4), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.scoreboard__avatar::after {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 18px 36px rgba(15, 23, 42, 0.32);
+  opacity: 0.7;
+}
+
+.scoreboard__avatar-image {
+  position: absolute;
+  inset: -2px;
+  width: calc(100% + 4px);
+  height: calc(100% + 4px);
+  border-radius: inherit;
+  object-fit: cover;
+  filter: saturate(1.15) contrast(1.05);
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.scoreboard__avatar-image[hidden] {
+  display: none;
+}
+
+.scoreboard__avatar-fallback {
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+  font-size: clamp(1rem, 2.5vw, 1.35rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--player-mark-color);
+  text-shadow:
+    0 0 12px rgba(255, 255, 255, 0.65),
+    0 0 18px var(--player-highlight);
+  mix-blend-mode: screen;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.scoreboard__avatar[data-avatar-type="image"] {
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.52),
+    rgba(148, 163, 184, 0.22)
+  );
+}
+
+.scoreboard__avatar[data-avatar-type="image"]::before {
+  opacity: 0.5;
+}
+
+.scoreboard__avatar[data-avatar-type="image"] .scoreboard__avatar-image {
+  opacity: 1;
+}
+
+.scoreboard__avatar[data-avatar-type="image"] .scoreboard__avatar-fallback {
+  opacity: 0;
+  transform: scale(0.88);
+}
+
+.scoreboard__avatar[data-avatar-type="orb"] {
+  background:
+    radial-gradient(
+      120% 120% at 28% 18%,
+      hsla(var(--avatar-hue), var(--avatar-saturation), calc(var(--avatar-lightness) + 8%), 0.92),
+      transparent 62%
+    ),
+    radial-gradient(
+      120% 120% at 75% 78%,
+      hsla(calc(var(--avatar-hue) + 40), calc(var(--avatar-saturation) - 10), calc(var(--avatar-lightness) + 6%), 0.58),
+      transparent 70%
+    ),
+    linear-gradient(
+      145deg,
+      hsla(var(--avatar-hue), calc(var(--avatar-saturation) - 18), calc(var(--avatar-lightness) + 14%), 0.82),
+      hsla(calc(var(--avatar-hue) + 55), var(--avatar-saturation), calc(var(--avatar-lightness) - 6%), 0.72)
+    );
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow:
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.42),
+    0 20px 40px rgba(15, 23, 42, 0.28),
+    0 0 34px hsla(var(--avatar-hue), var(--avatar-saturation), var(--avatar-lightness), 0.65);
+}
+
+.scoreboard__avatar[data-avatar-type="orb"]::before {
+  opacity: 0.95;
+}
+
+.scoreboard__avatar[data-avatar-type="orb"] .scoreboard__avatar-fallback {
+  opacity: 0;
+  transform: scale(0.88);
+}
+
+.scoreboard__avatar[data-avatar-type="mask"] {
+  background: linear-gradient(
+    140deg,
+    hsla(var(--avatar-hue), 62%, 62%, 0.65),
+    hsla(calc(var(--avatar-hue) + 35), 70%, 58%, 0.52),
+    rgba(148, 163, 184, 0.28)
+  );
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.scoreboard__avatar[data-avatar-type="mask"]::before {
+  opacity: 0.4;
+}
+
+.scoreboard__avatar[data-avatar-type="mask"]::after {
+  background: linear-gradient(
+    155deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(255, 255, 255, 0.25)
+  );
+  mask-image: var(--avatar-mask-image);
+  -webkit-mask-image: var(--avatar-mask-image);
+  mask-repeat: no-repeat;
+  mask-size: cover;
+  mix-blend-mode: lighten;
+  opacity: 0.9;
+}
+
+.scoreboard__avatar[data-avatar-type="mask"] .scoreboard__avatar-fallback {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.scoreboard__player:hover .scoreboard__avatar {
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.55),
+    inset 0 -22px 34px rgba(255, 255, 255, 0.26),
+    0 20px 40px rgba(15, 23, 42, 0.28),
+    0 0 32px var(--player-glow);
+}
+
+@media (prefers-color-scheme: dark) {
+  .scoreboard__avatar {
+    border-color: var(--avatar-border-dark);
+    background: linear-gradient(
+      145deg,
+      rgba(30, 58, 138, 0.55),
+      rgba(15, 23, 42, 0.82)
+    );
+    box-shadow:
+      inset 0 0 0 0.5px rgba(255, 255, 255, 0.18),
+      inset 0 -22px 34px rgba(148, 163, 184, 0.18),
+      0 20px 38px rgba(2, 6, 23, 0.55),
+      0 0 26px var(--player-highlight);
+  }
+
+  .scoreboard__avatar::after {
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+      0 0 0 1px rgba(148, 163, 184, 0.22),
+      0 24px 44px rgba(2, 6, 23, 0.6);
+  }
+
+  .scoreboard__avatar[data-avatar-type="image"] {
+    background: linear-gradient(
+      150deg,
+      rgba(30, 64, 175, 0.42),
+      rgba(15, 23, 42, 0.8)
+    );
+  }
+
+  .scoreboard__avatar[data-avatar-type="mask"] {
+    border-color: rgba(148, 163, 184, 0.42);
+  }
 }
 
 .scoreboard__mark {

--- a/site/index.html
+++ b/site/index.html
@@ -39,6 +39,29 @@
         aria-label="Player scoreboard"
       >
         <article class="scoreboard__player scoreboard__player--x" data-player="X">
+          <span
+            class="scoreboard__avatar"
+            data-role="avatar"
+            data-player="X"
+            aria-hidden="true"
+          >
+            <span
+              class="scoreboard__avatar-fallback"
+              data-role="avatar-fallback"
+              data-player="X"
+            >
+              PX
+            </span>
+            <img
+              class="scoreboard__avatar-image"
+              data-role="avatar-image"
+              data-player="X"
+              alt=""
+              loading="lazy"
+              decoding="async"
+              hidden
+            />
+          </span>
           <span class="scoreboard__mark" aria-hidden="true">X</span>
           <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
           <span class="scoreboard__score" data-player="X">
@@ -54,6 +77,29 @@
           </span>
         </article>
         <article class="scoreboard__player scoreboard__player--o" data-player="O">
+          <span
+            class="scoreboard__avatar"
+            data-role="avatar"
+            data-player="O"
+            aria-hidden="true"
+          >
+            <span
+              class="scoreboard__avatar-fallback"
+              data-role="avatar-fallback"
+              data-player="O"
+            >
+              PO
+            </span>
+            <img
+              class="scoreboard__avatar-image"
+              data-role="avatar-image"
+              data-player="O"
+              alt=""
+              loading="lazy"
+              decoding="async"
+              hidden
+            />
+          </span>
           <span class="scoreboard__mark" aria-hidden="true">O</span>
           <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
           <span class="scoreboard__score" data-player="O">

--- a/site/js/state/core.js
+++ b/site/js/state/core.js
@@ -6,9 +6,21 @@
   const NAME_PATTERN =
     window.coreState?.NAME_PATTERN ??
     /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+  const DEFAULT_AVATARS = {
+    X: null,
+    O: null,
+  };
+  const ORB_DEFAULTS = {
+    hue: 220,
+    saturation: 72,
+    lightness: 62,
+  };
+  /** @type {("X"|"O")[]} */
+  const PLAYERS = ["X", "O"];
 
   const listeners = new Map();
   let playerNames = { ...DEFAULT_NAMES };
+  let playerAvatars = { ...DEFAULT_AVATARS };
 
   const sanitiseName = (value, fallback) => {
     const trimmed = typeof value === "string" ? value.trim() : "";
@@ -22,6 +34,170 @@
     X: sanitiseName(nextNames?.X ?? "", DEFAULT_NAMES.X),
     O: sanitiseName(nextNames?.O ?? "", DEFAULT_NAMES.O),
   });
+
+  const clampNumber = (value, min, max, fallback) => {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    if (number < min) {
+      return min;
+    }
+    if (number > max) {
+      return max;
+    }
+    return number;
+  };
+
+  const sanitiseInitials = (value) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return "";
+    }
+    const characters = trimmed.match(/[\p{L}\p{N}]/gu);
+    if (!characters || !characters.length) {
+      return "";
+    }
+    return characters.slice(0, 3).join("").toUpperCase();
+  };
+
+  const isSafeImageSource = (value) => {
+    if (typeof value !== "string") {
+      return false;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return false;
+    }
+    if (/^data:image\//i.test(trimmed)) {
+      return true;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location ? window.location.href : "https://example.invalid/";
+      const url = new URL(trimmed, base);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const sanitiseAvatar = (value) => {
+    if (value === null || typeof value === "undefined") {
+      return null;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      return isSafeImageSource(trimmed) ? { type: "image", url: trimmed } : null;
+    }
+
+    if (typeof value !== "object") {
+      return null;
+    }
+
+    const rawType = typeof value.type === "string" ? value.type.toLowerCase() : "";
+    const type = rawType || (value.url || value.src ? "image" : "");
+
+    if (type === "image") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      return { type: "image", url };
+    }
+
+    if (type === "initials") {
+      const text = sanitiseInitials(value.text ?? value.value ?? "");
+      if (!text) {
+        return null;
+      }
+      return { type: "initials", text };
+    }
+
+    if (type === "orb" || type === "gradient") {
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      const saturation = clampNumber(
+        value.saturation ?? value.sat ?? ORB_DEFAULTS.saturation,
+        10,
+        100,
+        ORB_DEFAULTS.saturation
+      );
+      const lightness = clampNumber(
+        value.lightness ?? value.light ?? ORB_DEFAULTS.lightness,
+        10,
+        90,
+        ORB_DEFAULTS.lightness
+      );
+      return {
+        type: "orb",
+        hue,
+        saturation,
+        lightness,
+      };
+    }
+
+    if (type === "mask" || type === "svg") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      return {
+        type: "mask",
+        url,
+        hue,
+      };
+    }
+
+    return null;
+  };
+
+  const normaliseAvatars = (nextAvatars, base = DEFAULT_AVATARS) => {
+    const result = {
+      X: base.X ? { ...base.X } : null,
+      O: base.O ? { ...base.O } : null,
+    };
+
+    if (nextAvatars && typeof nextAvatars === "object") {
+      if (Object.prototype.hasOwnProperty.call(nextAvatars, "X")) {
+        result.X = sanitiseAvatar(nextAvatars.X);
+      }
+      if (Object.prototype.hasOwnProperty.call(nextAvatars, "O")) {
+        result.O = sanitiseAvatar(nextAvatars.O);
+      }
+    }
+
+    return result;
+  };
+
+  const cloneAvatar = (avatar) => (avatar ? { ...avatar } : null);
+
+  const getAvatarSnapshot = () => ({
+    X: cloneAvatar(playerAvatars.X),
+    O: cloneAvatar(playerAvatars.O),
+  });
+
+  const avatarsEqual = (left, right) =>
+    PLAYERS.every((player) => {
+      const current = left[player];
+      const next = right[player];
+      if (!current && !next) {
+        return true;
+      }
+      if (!current || !next) {
+        return false;
+      }
+      const currentKeys = Object.keys(current);
+      const nextKeys = Object.keys(next);
+      if (currentKeys.length !== nextKeys.length) {
+        return false;
+      }
+      return currentKeys.every((key) => current[key] === next[key]);
+    });
 
   const emit = (event, detail) => {
     const handlers = listeners.get(event);
@@ -44,6 +220,14 @@
     }
   };
 
+  const emitPlayersChanged = (source) => {
+    emit("players-changed", {
+      names: { ...playerNames },
+      avatars: getAvatarSnapshot(),
+      source,
+    });
+  };
+
   const setPlayerNames = (nextNames, options = {}) => {
     const { silent = false, source = "core" } = options;
     const normalised = normaliseNames(nextNames);
@@ -53,13 +237,24 @@
     playerNames = normalised;
 
     if (!silent && changed) {
-      emit("players-changed", {
-        names: { ...playerNames },
-        source,
-      });
+      emitPlayersChanged(source);
     }
 
     return { ...playerNames };
+  };
+
+  const setPlayerAvatars = (nextAvatars, options = {}) => {
+    const { silent = false, source = "core" } = options;
+    const normalised = normaliseAvatars(nextAvatars, playerAvatars);
+    const changed = !avatarsEqual(playerAvatars, normalised);
+
+    playerAvatars = normalised;
+
+    if (!silent && changed) {
+      emitPlayersChanged(source);
+    }
+
+    return getAvatarSnapshot();
   };
 
   const subscribe = (event, handler) => {
@@ -84,6 +279,7 @@
 
   const api = {
     DEFAULT_NAMES: { ...DEFAULT_NAMES },
+    DEFAULT_AVATARS: { ...DEFAULT_AVATARS },
     NAME_PATTERN,
     getPlayerNames() {
       return { ...playerNames };
@@ -94,6 +290,19 @@
     hydratePlayerNames(nextNames, options = {}) {
       const { emitUpdate = true, source = "hydrate" } = options;
       return setPlayerNames(nextNames, {
+        silent: !emitUpdate,
+        source,
+      });
+    },
+    getPlayerAvatars() {
+      return getAvatarSnapshot();
+    },
+    setPlayerAvatars(nextAvatars, options) {
+      return setPlayerAvatars(nextAvatars, options);
+    },
+    hydratePlayerAvatars(nextAvatars, options = {}) {
+      const { emitUpdate = true, source = "hydrate" } = options;
+      return setPlayerAvatars(nextAvatars, {
         silent: !emitUpdate,
         source,
       });

--- a/site/js/state/history.js
+++ b/site/js/state/history.js
@@ -6,12 +6,24 @@
   const NAME_PATTERN =
     window.coreState?.NAME_PATTERN ??
     /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+  const DEFAULT_AVATARS = {
+    X: null,
+    O: null,
+  };
+  const ORB_DEFAULTS = {
+    hue: 220,
+    saturation: 72,
+    lightness: 62,
+  };
+  /** @type {("X"|"O")[]} */
+  const PLAYERS = ["X", "O"];
 
   let coreSubscription = null;
   const listeners = new Map();
 
   const snapshot = {
     players: { ...DEFAULT_NAMES },
+    avatars: { ...DEFAULT_AVATARS },
   };
 
   const sanitiseName = (value, fallback) => {
@@ -26,6 +38,170 @@
     X: sanitiseName(names?.X ?? "", DEFAULT_NAMES.X),
     O: sanitiseName(names?.O ?? "", DEFAULT_NAMES.O),
   });
+
+  const clampNumber = (value, min, max, fallback) => {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    if (number < min) {
+      return min;
+    }
+    if (number > max) {
+      return max;
+    }
+    return number;
+  };
+
+  const sanitiseInitials = (value) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return "";
+    }
+    const characters = trimmed.match(/[\p{L}\p{N}]/gu);
+    if (!characters || !characters.length) {
+      return "";
+    }
+    return characters.slice(0, 3).join("").toUpperCase();
+  };
+
+  const isSafeImageSource = (value) => {
+    if (typeof value !== "string") {
+      return false;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return false;
+    }
+    if (/^data:image\//i.test(trimmed)) {
+      return true;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location ? window.location.href : "https://example.invalid/";
+      const url = new URL(trimmed, base);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const sanitiseAvatar = (value) => {
+    if (value === null || typeof value === "undefined") {
+      return null;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      return isSafeImageSource(trimmed) ? { type: "image", url: trimmed } : null;
+    }
+
+    if (typeof value !== "object") {
+      return null;
+    }
+
+    const rawType = typeof value.type === "string" ? value.type.toLowerCase() : "";
+    const type = rawType || (value.url || value.src ? "image" : "");
+
+    if (type === "image") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      return { type: "image", url };
+    }
+
+    if (type === "initials") {
+      const text = sanitiseInitials(value.text ?? value.value ?? "");
+      if (!text) {
+        return null;
+      }
+      return { type: "initials", text };
+    }
+
+    if (type === "orb" || type === "gradient") {
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      const saturation = clampNumber(
+        value.saturation ?? value.sat ?? ORB_DEFAULTS.saturation,
+        10,
+        100,
+        ORB_DEFAULTS.saturation
+      );
+      const lightness = clampNumber(
+        value.lightness ?? value.light ?? ORB_DEFAULTS.lightness,
+        10,
+        90,
+        ORB_DEFAULTS.lightness
+      );
+      return {
+        type: "orb",
+        hue,
+        saturation,
+        lightness,
+      };
+    }
+
+    if (type === "mask" || type === "svg") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      return {
+        type: "mask",
+        url,
+        hue,
+      };
+    }
+
+    return null;
+  };
+
+  const normaliseAvatars = (avatars, base = DEFAULT_AVATARS) => {
+    const result = {
+      X: base.X ? { ...base.X } : null,
+      O: base.O ? { ...base.O } : null,
+    };
+
+    if (avatars && typeof avatars === "object") {
+      if (Object.prototype.hasOwnProperty.call(avatars, "X")) {
+        result.X = sanitiseAvatar(avatars.X);
+      }
+      if (Object.prototype.hasOwnProperty.call(avatars, "O")) {
+        result.O = sanitiseAvatar(avatars.O);
+      }
+    }
+
+    return result;
+  };
+
+  const cloneAvatar = (avatar) => (avatar ? { ...avatar } : null);
+
+  const getAvatarSnapshot = () => ({
+    X: cloneAvatar(snapshot.avatars.X),
+    O: cloneAvatar(snapshot.avatars.O),
+  });
+
+  const avatarsEqual = (left, right) =>
+    PLAYERS.every((player) => {
+      const current = left[player];
+      const next = right[player];
+      if (!current && !next) {
+        return true;
+      }
+      if (!current || !next) {
+        return false;
+      }
+      const currentKeys = Object.keys(current);
+      const nextKeys = Object.keys(next);
+      if (currentKeys.length !== nextKeys.length) {
+        return false;
+      }
+      return currentKeys.every((key) => current[key] === next[key]);
+    });
 
   const emit = (event, detail) => {
     const handlers = listeners.get(event);
@@ -48,6 +224,14 @@
     }
   };
 
+  const emitPlayersChanged = (source) => {
+    emit("players-changed", {
+      names: { ...snapshot.players },
+      avatars: getAvatarSnapshot(),
+      source,
+    });
+  };
+
   const applyPlayerNames = (names, options = {}) => {
     const { silent = false, source = "history" } = options;
     const normalised = normaliseNames(names);
@@ -57,13 +241,24 @@
     snapshot.players = normalised;
 
     if (!silent && changed) {
-      emit("players-changed", {
-        names: { ...snapshot.players },
-        source,
-      });
+      emitPlayersChanged(source);
     }
 
     return { ...snapshot.players };
+  };
+
+  const applyPlayerAvatars = (avatars, options = {}) => {
+    const { silent = false, source = "history" } = options;
+    const normalised = normaliseAvatars(avatars, snapshot.avatars);
+    const changed = !avatarsEqual(snapshot.avatars, normalised);
+
+    snapshot.avatars = normalised;
+
+    if (!silent && changed) {
+      emitPlayersChanged(source);
+    }
+
+    return getAvatarSnapshot();
   };
 
   const subscribe = (event, handler) => {
@@ -105,15 +300,32 @@
       console.warn("Unable to synchronise player names from core state", error);
     }
 
+    try {
+      applyPlayerAvatars(core.getPlayerAvatars?.(), {
+        silent: true,
+        source: "core",
+      });
+    } catch (error) {
+      console.warn("Unable to synchronise player avatars from core state", error);
+    }
+
     if (typeof core.subscribe === "function") {
       coreSubscription = core.subscribe("players-changed", (detail) => {
-        if (!detail || !detail.names) {
+        if (!detail) {
           return;
         }
-        applyPlayerNames(detail.names, {
-          silent: false,
-          source: detail.source ?? "core",
-        });
+        if (detail.names) {
+          applyPlayerNames(detail.names, {
+            silent: false,
+            source: detail.source ?? "core",
+          });
+        }
+        if (Object.prototype.hasOwnProperty.call(detail, "avatars")) {
+          applyPlayerAvatars(detail.avatars, {
+            silent: false,
+            source: detail.source ?? "core",
+          });
+        }
       });
     }
   };
@@ -125,15 +337,23 @@
     setPlayerNames(names, options) {
       return applyPlayerNames(names, options);
     },
+    getPlayerAvatars() {
+      return getAvatarSnapshot();
+    },
+    setPlayerAvatars(avatars, options) {
+      return applyPlayerAvatars(avatars, options);
+    },
     getSharePayload(additional = {}) {
       return {
         ...additional,
         players: { ...snapshot.players },
+        avatars: getAvatarSnapshot(),
       };
     },
     getSnapshot() {
       return {
         players: { ...snapshot.players },
+        avatars: getAvatarSnapshot(),
       };
     },
     subscribe(event, handler) {
@@ -160,14 +380,23 @@
   if (typeof document !== "undefined") {
     document.addEventListener("state:players-changed", (event) => {
       const detail = event?.detail;
-      if (!detail || !detail.names) {
+      if (!detail) {
         return;
       }
 
-      applyPlayerNames(detail.names, {
-        silent: true,
-        source: detail.source ?? "core",
-      });
+      if (detail.names) {
+        applyPlayerNames(detail.names, {
+          silent: true,
+          source: detail.source ?? "core",
+        });
+      }
+
+      if (Object.prototype.hasOwnProperty.call(detail, "avatars")) {
+        applyPlayerAvatars(detail.avatars, {
+          silent: true,
+          source: detail.source ?? "core",
+        });
+      }
     });
   }
 })();

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -3,6 +3,204 @@
     X: "Player X",
     O: "Player O",
   };
+  const DEFAULT_AVATARS = {
+    X: null,
+    O: null,
+  };
+  const ORB_DEFAULTS = {
+    hue: 220,
+    saturation: 72,
+    lightness: 62,
+  };
+  /** @type {("X"|"O")[]} */
+  const PLAYERS = ["X", "O"];
+
+  const clampNumber = (value, min, max, fallback) => {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    if (number < min) {
+      return min;
+    }
+    if (number > max) {
+      return max;
+    }
+    return number;
+  };
+
+  const sanitiseInitials = (value) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return "";
+    }
+    const characters = trimmed.match(/[\p{L}\p{N}]/gu);
+    if (!characters || !characters.length) {
+      return "";
+    }
+    return characters.slice(0, 3).join("").toUpperCase();
+  };
+
+  const deriveInitialsFromName = (name, fallback) => {
+    const trimmed = typeof name === "string" ? name.trim() : "";
+    if (!trimmed) {
+      return fallback;
+    }
+
+    const words = trimmed.split(/\s+/u).filter(Boolean);
+    if (!words.length) {
+      return fallback;
+    }
+
+    const initials = [];
+    for (let index = 0; index < words.length && initials.length < 2; index += 1) {
+      const characters = Array.from(words[index]).filter((char) => /[\p{L}\p{N}]/u.test(char));
+      if (characters[0]) {
+        initials.push(characters[0]);
+      }
+    }
+
+    if (!initials.length) {
+      const characters = Array.from(words[0]).filter((char) => /[\p{L}\p{N}]/u.test(char));
+      if (characters[0]) {
+        initials.push(characters[0]);
+      }
+      if (characters.length > 1) {
+        const [, second = ""] = characters;
+        if (second) {
+          initials.push(second);
+        }
+      }
+    }
+
+    const derived = sanitiseInitials(initials.join(""));
+    if (derived) {
+      return derived;
+    }
+
+    const fallbackInitials = sanitiseInitials(words[0]);
+    return fallbackInitials || fallback;
+  };
+
+  const isSafeImageSource = (value) => {
+    if (typeof value !== "string") {
+      return false;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return false;
+    }
+    if (/^data:image\//i.test(trimmed)) {
+      return true;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location ? window.location.href : "https://example.invalid/";
+      const url = new URL(trimmed, base);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const sanitiseAvatar = (value) => {
+    if (value === null || typeof value === "undefined") {
+      return null;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      return isSafeImageSource(trimmed) ? { type: "image", url: trimmed } : null;
+    }
+
+    if (typeof value !== "object") {
+      return null;
+    }
+
+    const rawType = typeof value.type === "string" ? value.type.toLowerCase() : "";
+    const type = rawType || (value.url || value.src ? "image" : "");
+
+    if (type === "image") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      return { type: "image", url };
+    }
+
+    if (type === "initials") {
+      const text = sanitiseInitials(value.text ?? value.value ?? "");
+      if (!text) {
+        return null;
+      }
+      return { type: "initials", text };
+    }
+
+    if (type === "orb" || type === "gradient") {
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      const saturation = clampNumber(
+        value.saturation ?? value.sat ?? ORB_DEFAULTS.saturation,
+        10,
+        100,
+        ORB_DEFAULTS.saturation
+      );
+      const lightness = clampNumber(
+        value.lightness ?? value.light ?? ORB_DEFAULTS.lightness,
+        10,
+        90,
+        ORB_DEFAULTS.lightness
+      );
+      return {
+        type: "orb",
+        hue,
+        saturation,
+        lightness,
+      };
+    }
+
+    if (type === "mask" || type === "svg") {
+      const url = String(value.url ?? value.src ?? "").trim();
+      if (!url || !isSafeImageSource(url)) {
+        return null;
+      }
+      const hue = clampNumber(value.hue ?? value.tint ?? ORB_DEFAULTS.hue, 0, 360, ORB_DEFAULTS.hue);
+      return {
+        type: "mask",
+        url,
+        hue,
+      };
+    }
+
+    return null;
+  };
+
+  const normaliseAvatars = (avatars, base = DEFAULT_AVATARS) => {
+    const next = {
+      X: base.X ? { ...base.X } : null,
+      O: base.O ? { ...base.O } : null,
+    };
+
+    if (avatars && typeof avatars === "object") {
+      if (Object.prototype.hasOwnProperty.call(avatars, "X")) {
+        next.X = sanitiseAvatar(avatars.X);
+      }
+      if (Object.prototype.hasOwnProperty.call(avatars, "O")) {
+        next.O = sanitiseAvatar(avatars.O);
+      }
+    }
+
+    return next;
+  };
+
+  const cloneAvatar = (avatar) => (avatar ? { ...avatar } : null);
+
+  const toCssUrl = (value) => {
+    const escaped = String(value).replace(/[\n\r\f"\\]/g, "\$&");
+    return `url("${escaped}")`;
+  };
 
   document.addEventListener("DOMContentLoaded", () => {
     const statusMessage = document.getElementById("statusMessage");
@@ -13,6 +211,18 @@
     const scoreElements = {
       X: document.querySelector('[data-role="score"][data-player="X"]'),
       O: document.querySelector('[data-role="score"][data-player="O"]'),
+    };
+    const avatarElements = {
+      X: {
+        root: document.querySelector('[data-role="avatar"][data-player="X"]'),
+        fallback: document.querySelector('[data-role="avatar-fallback"][data-player="X"]'),
+        image: document.querySelector('[data-role="avatar-image"][data-player="X"]'),
+      },
+      O: {
+        root: document.querySelector('[data-role="avatar"][data-player="O"]'),
+        fallback: document.querySelector('[data-role="avatar-fallback"][data-player="O"]'),
+        image: document.querySelector('[data-role="avatar-image"][data-player="O"]'),
+      },
     };
     const playerCards = {
       X: document.querySelector('.scoreboard__player[data-player="X"]'),
@@ -25,6 +235,12 @@
       !nameElements.O ||
       !scoreElements.X ||
       !scoreElements.O ||
+      !avatarElements.X.root ||
+      !avatarElements.O.root ||
+      !avatarElements.X.fallback ||
+      !avatarElements.O.fallback ||
+      !avatarElements.X.image ||
+      !avatarElements.O.image ||
       !playerCards.X ||
       !playerCards.O
     ) {
@@ -32,6 +248,7 @@
     }
 
     let playerNames = { ...DEFAULT_NAMES };
+    let playerAvatars = { ...DEFAULT_AVATARS };
     let scores = { X: 0, O: 0 };
     let currentPlayer = "X";
     let statusState = "turn"; // "turn" | "win" | "draw"
@@ -66,11 +283,87 @@
       applyVisualState();
     };
 
+    const updateAvatarDisplay = () => {
+      PLAYERS.forEach((player) => {
+        const elements = avatarElements[player];
+        if (!elements || !elements.root) {
+          return;
+        }
+
+        const { root, fallback, image } = elements;
+        const config = playerAvatars[player];
+        let type = "initials";
+        let fallbackText = deriveInitialsFromName(playerNames[player], player);
+
+        root.style.removeProperty("--avatar-mask-image");
+        root.style.removeProperty("--avatar-hue");
+        root.style.removeProperty("--avatar-saturation");
+        root.style.removeProperty("--avatar-lightness");
+
+        if (image) {
+          image.hidden = true;
+        }
+
+        if (config?.type === "image" && config.url && image) {
+          type = "image";
+          if (image.src !== config.url) {
+            image.src = config.url;
+          }
+          image.hidden = false;
+        }
+
+        if (config?.type === "initials" && config.text) {
+          fallbackText = config.text;
+        }
+
+        if (fallback) {
+          fallback.textContent = fallbackText;
+        }
+
+        if (config?.type === "orb") {
+          type = "orb";
+          const hue = Number(config.hue);
+          const saturation = Number(config.saturation);
+          const lightness = Number(config.lightness);
+          root.style.setProperty(
+            "--avatar-hue",
+            Number.isFinite(hue) ? String(hue) : String(ORB_DEFAULTS.hue)
+          );
+          root.style.setProperty(
+            "--avatar-saturation",
+            Number.isFinite(saturation) ? `${saturation}%` : `${ORB_DEFAULTS.saturation}%`
+          );
+          root.style.setProperty(
+            "--avatar-lightness",
+            Number.isFinite(lightness) ? `${lightness}%` : `${ORB_DEFAULTS.lightness}%`
+          );
+        }
+
+        if (config?.type === "mask" && config.url) {
+          type = "mask";
+          root.style.setProperty("--avatar-mask-image", toCssUrl(config.url));
+          const hue = Number(config.hue);
+          root.style.setProperty(
+            "--avatar-hue",
+            Number.isFinite(hue) ? String(hue) : String(ORB_DEFAULTS.hue)
+          );
+        }
+
+        root.dataset.avatarType = type;
+      });
+    };
+
     const applyNames = (names) => {
       playerNames = { ...DEFAULT_NAMES, ...names };
       nameElements.X.textContent = playerNames.X;
       nameElements.O.textContent = playerNames.O;
       refreshStatus();
+      updateAvatarDisplay();
+    };
+
+    const applyAvatars = (avatars) => {
+      playerAvatars = normaliseAvatars(avatars, playerAvatars);
+      updateAvatarDisplay();
     };
 
     const updateScoreDisplay = () => {
@@ -123,6 +416,12 @@
       getNames() {
         return { ...playerNames };
       },
+      getAvatars() {
+        return {
+          X: cloneAvatar(playerAvatars.X),
+          O: cloneAvatar(playerAvatars.O),
+        };
+      },
     };
 
     window.uiStatus = api;
@@ -146,29 +445,44 @@
 
     document.addEventListener("settings:players-updated", (event) => {
       const detail = event?.detail;
-      if (!detail || !detail.names) {
+      if (!detail) {
         return;
       }
-      applyNames(detail.names);
+      if (detail.names) {
+        applyNames(detail.names);
+      }
+      if (Object.prototype.hasOwnProperty.call(detail, "avatars")) {
+        applyAvatars(detail.avatars);
+      }
     });
 
     document.addEventListener("state:players-changed", (event) => {
       const detail = event?.detail;
-      if (!detail || !detail.names) {
+      if (!detail) {
         return;
       }
-      applyNames(detail.names);
+      if (detail.names) {
+        applyNames(detail.names);
+      }
+      if (Object.prototype.hasOwnProperty.call(detail, "avatars")) {
+        applyAvatars(detail.avatars);
+      }
     });
 
     document.addEventListener("history:players-changed", (event) => {
       const detail = event?.detail;
-      if (!detail || !detail.names) {
+      if (!detail) {
         return;
       }
       if (detail.source && detail.source !== "history") {
         return;
       }
-      applyNames(detail.names);
+      if (detail.names) {
+        applyNames(detail.names);
+      }
+      if (Object.prototype.hasOwnProperty.call(detail, "avatars")) {
+        applyAvatars(detail.avatars);
+      }
     });
 
     applyNames(DEFAULT_NAMES);
@@ -185,6 +499,15 @@
         }
       } catch (error) {
         console.warn("Unable to read player names from core state", error);
+      }
+    }
+
+    if (core && typeof core.getPlayerAvatars === "function") {
+      try {
+        const avatars = core.getPlayerAvatars();
+        applyAvatars(avatars);
+      } catch (error) {
+        console.warn("Unable to read player avatars from core state", error);
       }
     }
   });


### PR DESCRIPTION
## Summary
- add avatar containers to each scoreboard player with lazy-loaded image slots and fallback initials
- create layered glass/glow avatar styling with theme-aware adjustments and mask/orb variants
- extend status, core, and history state modules to manage configurable avatar sources with sanitisation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fc8cae483289d75835404fa0a23