### PR TITLE
feat: improve scoreboard name responsiveness

### DIFF
--- a/docs/qa/scoreboard-name.md
+++ b/docs/qa/scoreboard-name.md
@@ -1,0 +1,20 @@
+# Manual QA: Scoreboard Name Responsiveness
+
+## Scenario
+Verify that player names at the 24-character limit render without breaking the glass card layout on both mobile and desktop breakpoints.
+
+## Test Data
+- Player X name: `AlexandriaLightningChamp`
+- Player O name: `TheStrategistSupreme24`
+
+## Steps
+1. Open the TicTacToe game page in a desktop browser at >=1280px width.
+2. Set the player names to the values above (24 characters each) via the scoreboard controls.
+3. Confirm that the names wrap or truncate within the glass card without overlapping the mark or score columns.
+4. Resize the viewport to ~375px width (or use a mobile simulator) and repeat step 3.
+5. Toggle a reduced-motion preference and confirm marquee animations are disabled while clamping still keeps the layout intact.
+
+## Expected Results
+- Typography scales responsively and remains legible at both breakpoints.
+- Long names wrap to at most two lines or gracefully ellipsize without pushing against the card edges.
+- With reduced motion enabled, no marquee animation plays and the layout remains stable.

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -554,6 +554,10 @@ button:focus-visible {
     justify-content: center;
     align-content: center;
   }
+
+  .scoreboard__player {
+    --scoreboard-name-max-inline-size: clamp(11rem, 26vw, 16rem);
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -577,6 +581,9 @@ button:focus-visible {
   --player-highlight: rgba(59, 130, 246, 0.42);
   --player-glow: rgba(59, 130, 246, 0.68);
   --player-mark-glow: rgba(59, 130, 246, 0.58);
+  --scoreboard-name-max-inline-size: clamp(9.5rem, 38vw, 12.5rem);
+  --scoreboard-name-max-lines: 2;
+  --scoreboard-name-marquee-duration: 11s;
   position: relative;
   z-index: 0;
   display: grid;
@@ -744,8 +751,73 @@ button:focus-visible {
 
 .scoreboard__name {
   font-weight: 600;
-  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+  font-size: clamp(1rem, 2.35vw, 1.25rem);
   letter-spacing: 0.01em;
+  line-height: 1.25;
+  max-inline-size: var(--scoreboard-name-max-inline-size, 100%);
+  text-wrap: balance;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--scoreboard-name-max-lines);
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+}
+
+@supports (line-clamp: 2) {
+  .scoreboard__name {
+    display: block;
+    line-clamp: var(--scoreboard-name-max-lines);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .scoreboard__name[data-marquee="true"] {
+    animation: scoreboard-name-marquee var(--scoreboard-name-marquee-duration)
+      linear infinite;
+    display: block;
+    white-space: nowrap;
+    max-inline-size: min(
+      var(--scoreboard-name-max-inline-size, 100%),
+      100%
+    );
+    overflow: hidden;
+    text-overflow: ellipsis;
+    will-change: transform;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scoreboard__name,
+  .scoreboard__name[data-marquee="true"] {
+    animation: none !important;
+  }
+}
+
+@keyframes scoreboard-name-marquee {
+  0% {
+    transform: translateX(0);
+  }
+
+  49% {
+    transform: translateX(0);
+  }
+
+  60% {
+    transform: translateX(
+      calc(
+        -1 * max(
+          0%,
+          var(--scoreboard-name-max-inline-size, 100%) - 100%
+        )
+      )
+    );
+  }
+
+  100% {
+    transform: translateX(0);
+  }
 }
 
 .scoreboard__score {


### PR DESCRIPTION
## What changed
- Tuned scoreboard name typography with responsive clamp sizing, wrapping, and new CSS custom properties for max inline sizes.
- Added optional marquee treatment gated by reduced-motion preferences and documented a manual QA scenario covering 24-character names.

## Why
- Long player names no longer break the glass card layout and the verification steps are captured for future QA runs.

## Screenshots
- n/a

## Testing notes
- [ ] Unit tests added or updated
- [ ] E2E ran green in CI

## A11y checklist
- [ ] Focus order verified
- [ ] ARIA roles and labels present
- [ ] Color contrast validated

------
https://chatgpt.com/codex/tasks/task_e_68df8fc969848328b0521b6525420688