### PR TITLE
feat: add move timeline to game UI

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1015,13 +1015,389 @@ button:focus-visible {
   .cell--winner {
     animation: none !important;
   }
+
+  .timeline__list {
+    scroll-behavior: auto;
+  }
 }
 
 .play-area {
   display: grid;
   gap: 24px;
-  align-content: space-between;
+  grid-template-areas:
+    "board"
+    "timeline"
+    "controls";
+  align-content: start;
   min-height: clamp(360px, 52vh, 520px);
+}
+
+.play-area .board {
+  grid-area: board;
+}
+
+.play-area .timeline {
+  grid-area: timeline;
+}
+
+.play-area .controls {
+  grid-area: controls;
+}
+
+@media (min-width: 960px) {
+  .play-area {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+    grid-template-areas:
+      "board timeline"
+      "controls timeline";
+    align-items: start;
+  }
+}
+
+@media (min-width: 1280px) {
+  .play-area {
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+  }
+}
+
+.timeline {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(18px, 3vw, 24px) clamp(18px, 3vw, 24px);
+  border-radius: 28px;
+  background: linear-gradient(
+      140deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(255, 255, 255, 0.58)
+    );
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 24px 48px var(--glass-shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  min-width: 0;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  inset: clamp(12px, 2vw, 18px) clamp(16px, 3vw, 22px) auto;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(59, 130, 246, 0.6),
+    rgba(129, 140, 248, 0.55),
+    rgba(14, 165, 233, 0.5)
+  );
+  opacity: 0.85;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+
+.timeline::after {
+  content: "";
+  position: absolute;
+  inset: auto -45% -60% 10%;
+  width: 120%;
+  height: 80%;
+  background: radial-gradient(
+    120% 120% at 0% 100%,
+    rgba(59, 130, 246, 0.2),
+    transparent 60%
+  );
+  filter: blur(48px);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.timeline[data-state="empty"]::before {
+  opacity: 0.55;
+}
+
+.timeline__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.timeline__title {
+  font-size: clamp(1.15rem, 2.8vw, 1.35rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.timeline__meta {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+.timeline__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.timeline__hint {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.timeline__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  max-height: min(360px, 45vh);
+  overflow-y: auto;
+  padding-right: 6px;
+  border-radius: 18px;
+  scroll-behavior: smooth;
+  outline: none;
+  position: relative;
+}
+
+.timeline__list:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.4);
+}
+
+.timeline__list::-webkit-scrollbar {
+  width: 10px;
+}
+
+.timeline__list::-webkit-scrollbar-track {
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+}
+
+.timeline__list::-webkit-scrollbar-thumb {
+  background: rgba(59, 130, 246, 0.45);
+  border-radius: 999px;
+}
+
+.timeline__empty {
+  margin: 0;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.timeline__item {
+  --timeline-accent: rgba(79, 70, 229, 0.9);
+  --timeline-accent-soft: rgba(79, 70, 229, 0.24);
+  --timeline-accent-glow: rgba(129, 140, 248, 0.36);
+  position: relative;
+}
+
+.timeline__item[data-player="X"] {
+  --timeline-accent: var(--accent);
+  --timeline-accent-soft: rgba(59, 130, 246, 0.25);
+  --timeline-accent-glow: rgba(96, 165, 250, 0.4);
+}
+
+.timeline__item[data-player="O"] {
+  --timeline-accent: var(--danger);
+  --timeline-accent-soft: rgba(220, 38, 38, 0.22);
+  --timeline-accent-glow: rgba(248, 113, 113, 0.38);
+}
+
+.timeline__card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 18px;
+  border-radius: 22px;
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.78),
+      rgba(255, 255, 255, 0.62)
+    );
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.timeline__card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--timeline-accent-soft), transparent 60%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.timeline__card::after {
+  content: "";
+  position: absolute;
+  inset: 10px auto 10px -68px;
+  width: 120px;
+  transform: skewX(-24deg);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.75),
+    transparent
+  );
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.timeline__avatar {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(44px, 7vw, 50px);
+  height: clamp(44px, 7vw, 50px);
+  border-radius: 18px;
+  font-weight: 700;
+  font-size: clamp(1.05rem, 2.8vw, 1.3rem);
+  color: #fff;
+  background: linear-gradient(135deg, var(--timeline-accent), var(--timeline-accent-glow));
+  box-shadow: 0 12px 22px var(--timeline-accent-soft);
+  text-shadow: 0 0 12px var(--timeline-accent);
+}
+
+.timeline__details {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.timeline__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.timeline__player {
+  font-weight: 600;
+  font-size: clamp(1rem, 2.4vw, 1.1rem);
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
+.timeline__time {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.timeline__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.timeline__turn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: var(--timeline-accent);
+  box-shadow: 0 6px 14px var(--timeline-accent-soft);
+}
+
+.timeline__location {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .timeline {
+    background: linear-gradient(
+        150deg,
+        rgba(17, 24, 39, 0.82),
+        rgba(30, 41, 59, 0.62)
+      );
+    box-shadow: 0 28px 52px rgba(8, 15, 35, 0.62);
+  }
+
+  .timeline::before {
+    background: linear-gradient(
+      90deg,
+      rgba(56, 189, 248, 0.5),
+      rgba(129, 140, 248, 0.45),
+      rgba(34, 211, 238, 0.4)
+    );
+  }
+
+  .timeline::after {
+    background: radial-gradient(
+      120% 120% at 0% 100%,
+      rgba(56, 189, 248, 0.2),
+      transparent 62%
+    );
+  }
+
+  .timeline__list::-webkit-scrollbar-track {
+    background: rgba(148, 163, 184, 0.24);
+  }
+
+  .timeline__list::-webkit-scrollbar-thumb {
+    background: rgba(96, 165, 250, 0.55);
+  }
+
+  .timeline__card {
+    background: linear-gradient(
+        145deg,
+        rgba(17, 24, 39, 0.86),
+        rgba(30, 41, 59, 0.7)
+      );
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: 0 20px 34px rgba(8, 15, 35, 0.62);
+  }
+
+  .timeline__card::after {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(148, 163, 184, 0.4),
+      transparent
+    );
+  }
+
+  .timeline__turn {
+    background: rgba(30, 41, 59, 0.72);
+    border-color: rgba(148, 163, 184, 0.32);
+  }
+
+  .timeline__empty {
+    background: rgba(17, 24, 39, 0.7);
+    border-color: rgba(148, 163, 184, 0.4);
+  }
 }
 
 .controls {

--- a/site/index.html
+++ b/site/index.html
@@ -153,6 +153,37 @@
           ></button>
         </section>
 
+        <aside
+          class="timeline"
+          id="timeline"
+          aria-label="Round timeline"
+          data-timeline
+        >
+          <header class="timeline__header">
+            <h2 class="timeline__title">Move timeline</h2>
+            <p class="timeline__meta" data-timeline-meta>
+              Waiting for the next round.
+            </p>
+          </header>
+          <div class="timeline__body">
+            <p id="timelineHelp" class="timeline__hint">
+              Focus this timeline and use arrow keys, Page Up, Page Down, Home, or
+              End to scroll through recorded moves.
+            </p>
+            <ol
+              class="timeline__list"
+              data-timeline-list
+              tabindex="0"
+              role="list"
+              aria-describedby="timelineHelp"
+              aria-live="polite"
+            ></ol>
+            <p class="timeline__empty" data-timeline-empty>
+              No moves recorded yet. Start a round to see each play appear here.
+            </p>
+          </div>
+        </aside>
+
         <footer class="controls">
           <div class="controls__group">
             <button
@@ -235,6 +266,7 @@
     </dialog>
 
     <script src="js/ui/status.js" defer></script>
+    <script src="js/ui/timeline.js" defer></script>
     <script src="js/app.js" defer></script>
     <script src="js/core/constants.js" defer></script>
     <script src="js/core/history.js" defer></script>

--- a/site/js/ui/timeline.js
+++ b/site/js/ui/timeline.js
@@ -1,0 +1,340 @@
+(function () {
+  const DEFAULT_NAMES = {
+    X: "Player X",
+    O: "Player O",
+  };
+  const BOARD_SIZE = 3;
+  const KEYBOARD_SCROLL_STEP = 72;
+  const PAGE_SCROLL_RATIO = 0.9;
+
+  const createTimeFormatter = () => {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+    } catch (error) {
+      console.warn("Unable to create timeline time formatter", error);
+      return null;
+    }
+  };
+
+  const readPlayerNamesFromCore = () => {
+    const core = window.coreState;
+    if (core && typeof core.getPlayerNames === "function") {
+      try {
+        const names = core.getPlayerNames();
+        if (names && typeof names === "object") {
+          return names;
+        }
+      } catch (error) {
+        console.warn("Unable to read player names for timeline", error);
+      }
+    }
+    return null;
+  };
+
+  const otherPlayer = (player) => {
+    if (player === "X") {
+      return "O";
+    }
+    if (player === "O") {
+      return "X";
+    }
+    return null;
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const timeline = document.querySelector("[data-timeline]");
+    if (!timeline) {
+      return;
+    }
+
+    const list = /** @type {HTMLOListElement | null} */ (
+      timeline.querySelector("[data-timeline-list]")
+    );
+    const meta = timeline.querySelector("[data-timeline-meta]");
+    const emptyMessage = timeline.querySelector("[data-timeline-empty]");
+
+    if (!list) {
+      return;
+    }
+
+    const reduceMotionQuery =
+      typeof window.matchMedia === "function"
+        ? window.matchMedia("(prefers-reduced-motion: reduce)")
+        : null;
+    const shouldReduceMotion = () => Boolean(reduceMotionQuery?.matches);
+
+    let turnCounter = 0;
+    let roundStartedAt = null;
+    let lastMoveAt = null;
+    let nextPlayer = null;
+    let playerNames = { ...DEFAULT_NAMES };
+
+    const timeFormatter = createTimeFormatter();
+
+    const formatTimestamp = (date) => {
+      if (!date) {
+        return "";
+      }
+      if (timeFormatter) {
+        try {
+          return timeFormatter.format(date);
+        } catch (error) {
+          console.warn("Unable to format timeline timestamp", error);
+        }
+      }
+      return date.toLocaleTimeString();
+    };
+
+    const formatCellPosition = (index) => {
+      const row = Math.floor(index / BOARD_SIZE) + 1;
+      const column = (index % BOARD_SIZE) + 1;
+      return { row, column };
+    };
+
+    const scrollByAmount = (delta) => {
+      if (typeof list.scrollBy === "function" && !shouldReduceMotion()) {
+        list.scrollBy({ top: delta, behavior: "smooth" });
+        return;
+      }
+      list.scrollTop += delta;
+    };
+
+    const scrollToPosition = (top) => {
+      if (typeof list.scrollTo === "function" && !shouldReduceMotion()) {
+        list.scrollTo({ top, behavior: "smooth" });
+        return;
+      }
+      list.scrollTop = top;
+    };
+
+    const scrollListToEnd = () => {
+      scrollToPosition(list.scrollHeight);
+    };
+
+    const setEmptyState = (isEmpty) => {
+      if (emptyMessage) {
+        emptyMessage.hidden = !isEmpty;
+      }
+      timeline.dataset.state = isEmpty ? "empty" : "active";
+    };
+
+    const updateMeta = () => {
+      if (!meta) {
+        return;
+      }
+
+      if (!roundStartedAt) {
+        meta.textContent = "Waiting for the next round.";
+        return;
+      }
+
+      const startTime = formatTimestamp(roundStartedAt);
+
+      if (!turnCounter) {
+        const opener =
+          nextPlayer && (playerNames[nextPlayer] || `Player ${nextPlayer}`);
+        meta.textContent = opener
+          ? `Round started at ${startTime} — ${opener} to move.`
+          : `Round started at ${startTime}.`;
+        return;
+      }
+
+      const lastTime = formatTimestamp(lastMoveAt);
+      if (nextPlayer) {
+        const name = playerNames[nextPlayer] || `Player ${nextPlayer}`;
+        meta.textContent = `Turn ${turnCounter} played at ${lastTime} — next: ${name}.`;
+      } else {
+        meta.textContent = `Round completed at ${lastTime} after ${turnCounter} turns.`;
+      }
+    };
+
+    const refreshNameBadges = () => {
+      list.querySelectorAll("[data-player-name]").forEach((element) => {
+        const id = element.getAttribute("data-player-name");
+        if (!id) {
+          return;
+        }
+        element.textContent = playerNames[id] || `Player ${id}`;
+      });
+    };
+
+    const applyPlayerNames = (names) => {
+      if (!names || typeof names !== "object") {
+        return;
+      }
+      playerNames = { ...playerNames, ...names };
+      refreshNameBadges();
+      updateMeta();
+    };
+
+    const buildMoveItem = (detail, turnNumber) => {
+      const { player, index } = detail;
+      if (!player || typeof index !== "number") {
+        return null;
+      }
+
+      const timestamp = new Date();
+      const { row, column } = formatCellPosition(index);
+
+      const item = document.createElement("li");
+      item.className = "timeline__item";
+      item.dataset.player = player;
+      item.dataset.turn = String(turnNumber);
+
+      const card = document.createElement("article");
+      card.className = "timeline__card";
+
+      const avatar = document.createElement("span");
+      avatar.className = "timeline__avatar";
+      avatar.setAttribute("aria-hidden", "true");
+      avatar.textContent = player;
+
+      const details = document.createElement("div");
+      details.className = "timeline__details";
+
+      const topRow = document.createElement("div");
+      topRow.className = "timeline__row";
+
+      const playerLabel = document.createElement("span");
+      playerLabel.className = "timeline__player";
+      playerLabel.dataset.playerName = player;
+      playerLabel.textContent = playerNames[player] || `Player ${player}`;
+
+      const timeElement = document.createElement("time");
+      timeElement.className = "timeline__time";
+      timeElement.dateTime = timestamp.toISOString();
+      timeElement.textContent = formatTimestamp(timestamp);
+
+      topRow.append(playerLabel, timeElement);
+
+      const summary = document.createElement("p");
+      summary.className = "timeline__summary";
+
+      const turnBadge = document.createElement("span");
+      turnBadge.className = "timeline__turn";
+      turnBadge.textContent = `Turn ${turnNumber}`;
+
+      const location = document.createElement("span");
+      location.className = "timeline__location";
+      location.textContent = `Row ${row} · Column ${column}`;
+
+      summary.append(turnBadge, location);
+
+      details.append(topRow, summary);
+      card.append(avatar, details);
+      item.append(card);
+
+      return { item, timestamp };
+    };
+
+    const resetTimeline = (detail) => {
+      list.innerHTML = "";
+      list.scrollTop = 0;
+      turnCounter = 0;
+      roundStartedAt = new Date();
+      lastMoveAt = null;
+      nextPlayer = detail?.currentPlayer || null;
+      setEmptyState(true);
+      updateMeta();
+    };
+
+    const handleMovePlayed = (detail) => {
+      if (!detail || typeof detail.index !== "number" || !detail.player) {
+        return;
+      }
+
+      turnCounter += 1;
+      const entry = buildMoveItem(detail, turnCounter);
+      if (!entry) {
+        turnCounter -= 1;
+        return;
+      }
+
+      list.append(entry.item);
+      lastMoveAt = entry.timestamp;
+      nextPlayer = detail.isRoundOver ? null : otherPlayer(detail.player);
+      setEmptyState(false);
+      updateMeta();
+      scrollListToEnd();
+    };
+
+    const handleKeyboardScroll = (event) => {
+      const { key } = event;
+      if (!key) {
+        return;
+      }
+
+      const pageStep = Math.max(list.clientHeight * PAGE_SCROLL_RATIO, KEYBOARD_SCROLL_STEP * 2);
+
+      switch (key) {
+        case "ArrowDown":
+          scrollByAmount(KEYBOARD_SCROLL_STEP);
+          event.preventDefault();
+          break;
+        case "ArrowUp":
+          scrollByAmount(-KEYBOARD_SCROLL_STEP);
+          event.preventDefault();
+          break;
+        case "PageDown":
+          scrollByAmount(pageStep);
+          event.preventDefault();
+          break;
+        case "PageUp":
+          scrollByAmount(-pageStep);
+          event.preventDefault();
+          break;
+        case "Home":
+          if (list.scrollTop > 0) {
+            scrollToPosition(0);
+            event.preventDefault();
+          }
+          break;
+        case "End":
+          if (list.scrollTop + list.clientHeight < list.scrollHeight) {
+            scrollToPosition(list.scrollHeight);
+            event.preventDefault();
+          }
+          break;
+        default:
+          break;
+      }
+    };
+
+    list.addEventListener("keydown", handleKeyboardScroll);
+
+    document.addEventListener("game:round-started", (event) => {
+      resetTimeline(event?.detail || {});
+    });
+
+    document.addEventListener("game:move-played", (event) => {
+      handleMovePlayed(event?.detail || {});
+    });
+
+    document.addEventListener("settings:players-updated", (event) => {
+      applyPlayerNames(event?.detail?.names);
+    });
+
+    document.addEventListener("state:players-changed", (event) => {
+      applyPlayerNames(event?.detail?.names);
+    });
+
+    document.addEventListener("history:players-changed", (event) => {
+      const detail = event?.detail;
+      if (!detail || detail.source === "history" || !detail.source) {
+        applyPlayerNames(detail?.names);
+      }
+    });
+
+    setEmptyState(true);
+    updateMeta();
+
+    const initialNames = readPlayerNamesFromCore();
+    if (initialNames) {
+      applyPlayerNames(initialNames);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a move timeline panel with accessible markup and guidance in the game layout
- style the timeline with glassmorphism cards, accent streaks, and responsive placement alongside the board
- implement a UI timeline controller that tracks game events and supports keyboard scrolling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fca4f1083288c7ca62031a26eb5