### PR TITLE
Add celebratory animation utilities for win and draw states

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -865,6 +865,60 @@ button:focus-visible {
   backdrop-filter: blur(18px) saturate(140%);
 }
 
+.board::after {
+  content: "";
+  position: absolute;
+  inset: clamp(4px, 1vw, 10px);
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  background: radial-gradient(
+      circle at 50% 50%,
+      var(--board-effect-accent, rgba(59, 130, 246, 0.28)),
+      transparent 68%
+    ),
+    radial-gradient(
+      circle at 50% 50%,
+      var(--board-effect-secondary, rgba(56, 189, 248, 0.22)),
+      transparent 75%
+    );
+  box-shadow: 0 0 42px var(--board-effect-color, rgba(59, 130, 246, 0.35));
+  filter: blur(0.5px);
+  transition: opacity 260ms ease, transform 260ms ease;
+  transform: scale(0.96);
+}
+
+.board--celebrate::after,
+.board--draw-flash::after {
+  opacity: 1;
+  transform: scale(1.04);
+}
+
+.board--celebrate {
+  box-shadow: 0 22px 60px rgba(15, 23, 42, 0.3),
+    0 0 0 2px rgba(255, 255, 255, 0.32),
+    0 0 32px var(--board-effect-color, rgba(59, 130, 246, 0.35));
+}
+
+.board--draw-flash {
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.28),
+    0 0 0 2px rgba(255, 255, 255, 0.28),
+    0 0 32px var(--board-effect-color, rgba(129, 140, 248, 0.3));
+}
+
+.board--draw-flash::after {
+  background: radial-gradient(
+      circle at 40% 40%,
+      var(--board-effect-accent, rgba(167, 139, 250, 0.26)),
+      transparent 70%
+    ),
+    radial-gradient(
+      circle at 60% 60%,
+      var(--board-effect-secondary, rgba(129, 140, 248, 0.24)),
+      transparent 78%
+    );
+}
+
 .cell {
   --cell-mark-color: var(--surface-strong);
   --cell-glow-color: rgba(37, 99, 235, 0.2);
@@ -1361,6 +1415,104 @@ dialog.is-closing::backdrop {
   color: var(--danger);
 }
 
+.effect-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 24;
+  mix-blend-mode: screen;
+  isolation: isolate;
+  opacity: 1;
+  transition: opacity 260ms ease;
+}
+
+.effect-overlay--fade-out {
+  opacity: 0;
+}
+
+.effect-overlay__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.effect-overlay__radial {
+  position: absolute;
+  left: var(--glow-center-x, 50%);
+  top: var(--glow-center-y, 50%);
+  width: var(--glow-size, 320px);
+  height: var(--glow-size, 320px);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(
+      circle at 50% 50%,
+      var(--effect-tone-accent, rgba(59, 130, 246, 0.32)),
+      transparent 58%
+    ),
+    radial-gradient(
+      circle at 50% 50%,
+      var(--effect-tone-secondary, rgba(96, 165, 250, 0.28)),
+      transparent 85%
+    );
+  box-shadow: 0 0 65px var(--effect-tone-color, rgba(59, 130, 246, 0.38));
+  filter: blur(0.5px);
+  opacity: 0.95;
+  animation: radial-glow-burst var(--glow-duration, 1200ms) ease-out forwards;
+}
+
+.effect-overlay__particle-field {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.effect-overlay__particle {
+  position: absolute;
+  left: var(--particle-start-x, 50%);
+  top: var(--particle-start-y, 50%);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), transparent 70%),
+    radial-gradient(circle at 50% 50%, var(--effect-tone-accent, rgba(167, 139, 250, 0.45)), transparent 85%);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.18);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transform: translate3d(0, 0, 0) scale(0.55);
+  animation: particle-float var(--particle-duration, 1400ms) ease-out forwards;
+  animation-delay: var(--particle-delay, 0ms);
+}
+
+@keyframes radial-glow-burst {
+  0% {
+    opacity: 0.95;
+    transform: translate(-50%, -50%) scale(0.75);
+    filter: blur(0px);
+  }
+  55% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.6);
+    filter: blur(18px);
+  }
+}
+
+@keyframes particle-float {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0) scale(0.45);
+  }
+  25% {
+    opacity: 0.95;
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--particle-dx, 0px), var(--particle-dy, -24px), 0)
+      scale(0.1);
+  }
+}
+
 @media (max-width: 600px) {
   .app-shell {
     padding: 20px 16px;
@@ -1387,7 +1539,9 @@ dialog.is-closing::backdrop {
   .button,
   .controls .button,
   .toolbar__actions .button,
-  .status {
+  .status,
+  .board,
+  .board::after {
     transition: none;
   }
 
@@ -1398,5 +1552,10 @@ dialog.is-closing::backdrop {
   .toolbar__actions .button:hover,
   .toolbar__actions .button:active {
     transform: none;
+  }
+
+  .board--celebrate,
+  .board--draw-flash {
+    box-shadow: 0 0 0 2px var(--board-effect-color, rgba(148, 163, 184, 0.25));
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -235,6 +235,7 @@
     </dialog>
 
     <script src="js/ui/status.js" defer></script>
+    <script src="js/ui/effects.js" defer></script>
     <script src="js/app.js" defer></script>
     <script src="js/core/constants.js" defer></script>
     <script src="js/core/history.js" defer></script>

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -274,6 +274,28 @@
       });
     };
 
+    const runWinEffects = (player) => {
+      const effects = global.uiEffects;
+      if (!effects) {
+        return;
+      }
+      const tone = player === PLAYER_X ? 'x' : 'o';
+      if (typeof effects.playConfetti === 'function') {
+        effects.playConfetti({ tone });
+      }
+      if (typeof effects.playRadialGlow === 'function') {
+        effects.playRadialGlow(boardElement, { tone });
+      }
+    };
+
+    const runDrawEffects = () => {
+      const effects = global.uiEffects;
+      if (!effects || typeof effects.playParticleOverlay !== 'function') {
+        return;
+      }
+      effects.playParticleOverlay(boardElement, { tone: 'draw' });
+    };
+
     const refreshBoardUi = () => {
       cells.forEach((cell, index) => {
         const value = board[index];
@@ -362,6 +384,7 @@
 
       announceWin(player);
       highlightWinningLine(line);
+      runWinEffects(player);
       cells.forEach((cell) => setCellDisabled(cell, true));
       dispatchEvent('round-ended', {
         result: 'win',
@@ -373,6 +396,7 @@
 
     const handleDraw = () => {
       announceDraw();
+      runDrawEffects();
       cells.forEach((cell) => setCellDisabled(cell, true));
       dispatchEvent('round-ended', {
         result: 'draw',

--- a/site/js/ui/effects.js
+++ b/site/js/ui/effects.js
@@ -1,0 +1,324 @@
+'use strict';
+
+(function (global) {
+  const reduceMotionQuery =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+
+  const toneMap = {
+    x: {
+      color: 'rgba(37, 99, 235, 0.55)',
+      accent: 'rgba(59, 130, 246, 0.35)',
+      secondary: 'rgba(96, 165, 250, 0.32)',
+    },
+    o: {
+      color: 'rgba(220, 38, 38, 0.52)',
+      accent: 'rgba(248, 113, 113, 0.35)',
+      secondary: 'rgba(239, 68, 68, 0.28)',
+    },
+    draw: {
+      color: 'rgba(139, 92, 246, 0.45)',
+      accent: 'rgba(167, 139, 250, 0.35)',
+      secondary: 'rgba(129, 140, 248, 0.32)',
+    },
+  };
+
+  const resolveTone = (tone) => {
+    const key = typeof tone === 'string' ? tone.toLowerCase() : '';
+    return toneMap[key] || toneMap.x;
+  };
+
+  const shouldReduceMotion = () => Boolean(reduceMotionQuery?.matches);
+
+  const overlays = new Set();
+
+  const removeOverlay = (overlay) => {
+    if (!overlay) {
+      return;
+    }
+    overlays.delete(overlay);
+    if (overlay.parentNode) {
+      overlay.parentNode.removeChild(overlay);
+    }
+  };
+
+  const createOverlay = (extraClassName, tone) => {
+    if (typeof document === 'undefined') {
+      return null;
+    }
+    const root = document.body || document.documentElement;
+    if (!root) {
+      return null;
+    }
+
+    const overlay = document.createElement('div');
+    overlay.className = `effect-overlay${extraClassName ? ` ${extraClassName}` : ''}`;
+    overlay.setAttribute('aria-hidden', 'true');
+
+    if (tone) {
+      overlay.dataset.tone = tone;
+      const resolved = resolveTone(tone);
+      overlay.style.setProperty('--effect-tone-color', resolved.color);
+      overlay.style.setProperty('--effect-tone-accent', resolved.accent);
+      overlay.style.setProperty('--effect-tone-secondary', resolved.secondary);
+    }
+
+    overlays.add(overlay);
+    root.appendChild(overlay);
+    return overlay;
+  };
+
+  const addBoardHighlight = (target, tone, className, duration) => {
+    if (!target) {
+      return;
+    }
+    const resolved = resolveTone(tone);
+    target.classList.add(className);
+    target.style.setProperty('--board-effect-color', resolved.color);
+    target.style.setProperty('--board-effect-accent', resolved.accent);
+    target.style.setProperty('--board-effect-secondary', resolved.secondary);
+    window.setTimeout(() => {
+      target.classList.remove(className);
+      target.style.removeProperty('--board-effect-color');
+      target.style.removeProperty('--board-effect-accent');
+      target.style.removeProperty('--board-effect-secondary');
+    }, duration);
+  };
+
+  const playConfetti = ({ duration = 1800, particleCount = 140, tone = 'x' } = {}) => {
+    if (shouldReduceMotion()) {
+      return Promise.resolve();
+    }
+
+    const overlay = createOverlay('effect-overlay--confetti', tone);
+    if (!overlay) {
+      return Promise.resolve();
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.className = 'effect-overlay__canvas';
+    overlay.appendChild(canvas);
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      removeOverlay(overlay);
+      return Promise.resolve();
+    }
+
+    let width = overlay.clientWidth;
+    let height = overlay.clientHeight;
+
+    const resize = () => {
+      width = overlay.clientWidth;
+      height = overlay.clientHeight;
+      const scale = window.devicePixelRatio || 1;
+      canvas.width = Math.floor(width * scale);
+      canvas.height = Math.floor(height * scale);
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      context.scale(scale, scale);
+    };
+
+    resize();
+
+    const resolved = resolveTone(tone);
+    const palette = [resolved.accent, resolved.secondary, resolved.color, 'rgba(255, 255, 255, 0.65)'];
+
+    const randomBetween = (min, max) => Math.random() * (max - min) + min;
+
+    const particles = Array.from({ length: particleCount }, () => ({
+      x: randomBetween(0, width),
+      y: randomBetween(-height * 0.5, 0),
+      w: randomBetween(6, 12),
+      h: randomBetween(12, 24),
+      vx: randomBetween(-0.6, 0.6),
+      vy: randomBetween(1.2, 2.6),
+      rotation: randomBetween(0, Math.PI * 2),
+      rotationSpeed: randomBetween(-0.2, 0.2),
+      opacity: randomBetween(0.65, 1),
+      color: palette[Math.floor(Math.random() * palette.length)],
+    }));
+
+    let animationFrame = null;
+    let startTime = null;
+    let lastTime = null;
+
+    const step = (timestamp) => {
+      if (!startTime) {
+        startTime = timestamp;
+        lastTime = timestamp;
+      }
+      const elapsed = timestamp - startTime;
+      const delta = timestamp - lastTime;
+      lastTime = timestamp;
+
+      context.clearRect(0, 0, width, height);
+      particles.forEach((particle) => {
+        particle.x += particle.vx * (delta / 16.6667);
+        particle.y += particle.vy * (delta / 16.6667);
+        particle.vy += 0.012 * (delta / 16.6667);
+        particle.rotation += particle.rotationSpeed * (delta / 16.6667);
+
+        if (particle.y > height + 50) {
+          particle.y = randomBetween(-height * 0.3, -20);
+          particle.x = randomBetween(0, width);
+          particle.vy = randomBetween(1.1, 2.3);
+        }
+
+        context.save();
+        context.globalAlpha = particle.opacity * (1 - elapsed / duration);
+        context.translate(particle.x, particle.y);
+        context.rotate(particle.rotation);
+        context.fillStyle = particle.color;
+        context.fillRect(-particle.w / 2, -particle.h / 2, particle.w, particle.h);
+        context.restore();
+      });
+
+      if (elapsed < duration) {
+        animationFrame = window.requestAnimationFrame(step);
+      } else {
+        animationFrame = null;
+        overlay.classList.add('effect-overlay--fade-out');
+      }
+    };
+
+    const handleResize = () => {
+      resize();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    animationFrame = window.requestAnimationFrame(step);
+
+    return new Promise((resolve) => {
+      const cleanup = () => {
+        window.removeEventListener('resize', handleResize);
+        if (animationFrame) {
+          window.cancelAnimationFrame(animationFrame);
+        }
+        removeOverlay(overlay);
+        resolve();
+      };
+
+      window.setTimeout(cleanup, duration + 260);
+    });
+  };
+
+  const playRadialGlow = (target, { tone = 'x', duration = 1200 } = {}) => {
+    if (!target) {
+      return Promise.resolve();
+    }
+
+    if (shouldReduceMotion()) {
+      addBoardHighlight(target, tone, 'board--celebrate', duration);
+      return Promise.resolve();
+    }
+
+    const overlay = createOverlay('effect-overlay--radial', tone);
+    if (!overlay) {
+      return Promise.resolve();
+    }
+
+    const glow = document.createElement('div');
+    glow.className = 'effect-overlay__radial';
+    overlay.appendChild(glow);
+
+    const setPosition = () => {
+      const rect = target.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2 + window.scrollX;
+      const centerY = rect.top + rect.height / 2 + window.scrollY;
+      const size = Math.max(rect.width, rect.height) * 1.6;
+      glow.style.setProperty('--glow-center-x', `${centerX}px`);
+      glow.style.setProperty('--glow-center-y', `${centerY}px`);
+      glow.style.setProperty('--glow-size', `${size}px`);
+      glow.style.setProperty('--glow-duration', `${duration}ms`);
+    };
+
+    setPosition();
+
+    const handleResize = () => {
+      setPosition();
+    };
+
+    window.addEventListener('resize', handleResize, { once: true });
+
+    return new Promise((resolve) => {
+      window.setTimeout(() => {
+        removeOverlay(overlay);
+        resolve();
+      }, duration + 200);
+    });
+  };
+
+  const playParticleOverlay = (
+    target,
+    { tone = 'draw', count = 26, duration = 1400 } = {}
+  ) => {
+    if (!target) {
+      return Promise.resolve();
+    }
+
+    if (shouldReduceMotion()) {
+      addBoardHighlight(target, tone, 'board--draw-flash', duration);
+      return Promise.resolve();
+    }
+
+    const overlay = createOverlay('effect-overlay--particles', tone);
+    if (!overlay) {
+      return Promise.resolve();
+    }
+
+    const field = document.createElement('div');
+    field.className = 'effect-overlay__particle-field';
+    overlay.appendChild(field);
+
+    const rect = target.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2 + window.scrollX;
+    const centerY = rect.top + rect.height / 2 + window.scrollY;
+    const radius = Math.max(rect.width, rect.height) * 0.65;
+
+    field.style.setProperty('--particle-center-x', `${centerX}px`);
+    field.style.setProperty('--particle-center-y', `${centerY}px`);
+    field.style.setProperty('--particle-radius', `${radius}px`);
+
+    for (let index = 0; index < count; index += 1) {
+      const particle = document.createElement('span');
+      particle.className = 'effect-overlay__particle';
+      const angle = Math.random() * Math.PI * 2;
+      const distance = radius * (0.4 + Math.random() * 0.6);
+      const startDistance = distance * 0.35;
+      const startX = centerX + Math.cos(angle) * startDistance;
+      const startY = centerY + Math.sin(angle) * startDistance;
+      const endX = centerX + Math.cos(angle) * distance;
+      const endY = centerY + Math.sin(angle) * distance;
+      const delay = Math.random() * 140;
+      const life = duration + Math.random() * 360;
+      const size = 6 + Math.random() * 9;
+      particle.style.setProperty('--particle-delay', `${delay}ms`);
+      particle.style.setProperty('--particle-duration', `${life}ms`);
+      particle.style.setProperty('--particle-start-x', `${startX}px`);
+      particle.style.setProperty('--particle-start-y', `${startY}px`);
+      particle.style.setProperty('--particle-dx', `${endX - startX}px`);
+      particle.style.setProperty('--particle-dy', `${endY - startY}px`);
+      particle.style.width = `${size}px`;
+      particle.style.height = `${size}px`;
+      field.appendChild(particle);
+    }
+
+    return new Promise((resolve) => {
+      window.setTimeout(() => {
+        removeOverlay(overlay);
+        resolve();
+      }, duration + 520);
+    });
+  };
+
+  const api = {
+    playConfetti,
+    playRadialGlow,
+    playParticleOverlay,
+    prefersReducedMotion: shouldReduceMotion,
+  };
+
+  global.uiEffects = api;
+})(window);


### PR DESCRIPTION
## Summary
- add a reusable UI effects module that renders confetti, radial glow, and particle overlays with reduced-motion fallbacks
- hook the new effects into the win and draw handlers and ensure the script loads with the rest of the UI
- style board highlights and overlay layers to match the existing glass aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fcb8184832880dfc358cf463c2d