### PR TITLE
Add glowing board indicator synced with active player

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -847,6 +847,85 @@ button:focus-visible {
   background: radial-gradient(120% 120% at 20% 20%, var(--glow-neutral), transparent);
 }
 
+.board-indicator {
+  --board-ring-color: rgba(37, 99, 235, 0.45);
+  --board-ring-sheen: rgba(191, 219, 254, 0.65);
+  --board-ring-shadow: rgba(59, 130, 246, 0.35);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 4vw, 34px);
+  margin-inline: auto;
+}
+
+.board-indicator::before,
+.board-indicator::after {
+  content: "";
+  position: absolute;
+  inset: clamp(-34px, -6vw, -22px);
+  border-radius: clamp(48px, 12vw, 72px);
+  pointer-events: none;
+  opacity: 0.65;
+  transition: opacity 280ms ease, filter 280ms ease;
+}
+
+.board-indicator::before {
+  background: radial-gradient(60% 60% at 50% 50%, var(--board-ring-sheen), transparent 70%);
+  filter: blur(12px);
+  animation: board-ring-pulse 3.4s ease-in-out infinite;
+}
+
+.board-indicator::after {
+  background: conic-gradient(
+    from 0deg,
+    color-mix(in srgb, var(--board-ring-color) 55%, transparent) 0deg,
+    transparent 120deg,
+    color-mix(in srgb, var(--board-ring-color) 35%, transparent) 240deg,
+    transparent 360deg
+  );
+  filter: blur(22px);
+  opacity: 0.75;
+}
+
+.board-indicator.is-turn-x {
+  --board-ring-color: rgba(37, 99, 235, 0.58);
+  --board-ring-sheen: rgba(191, 219, 254, 0.82);
+  --board-ring-shadow: rgba(59, 130, 246, 0.45);
+}
+
+.board-indicator.is-turn-o {
+  --board-ring-color: rgba(220, 38, 38, 0.6);
+  --board-ring-sheen: rgba(254, 202, 202, 0.8);
+  --board-ring-shadow: rgba(248, 113, 113, 0.42);
+}
+
+.board-indicator.is-turn-x::before,
+.board-indicator.is-turn-o::before {
+  animation-duration: 2.6s;
+}
+
+.board-indicator.is-turn-x::after,
+.board-indicator.is-turn-o::after {
+  opacity: 0.85;
+  filter: blur(18px);
+}
+
+@keyframes board-ring-pulse {
+  0% {
+    opacity: 0.55;
+    transform: scale(0.96);
+  }
+  45% {
+    opacity: 0.9;
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0.6;
+    transform: scale(0.96);
+  }
+}
+
 .board {
   position: relative;
   display: grid;
@@ -861,7 +940,7 @@ button:focus-visible {
     linear-gradient(160deg, rgba(37, 99, 235, 0.35), rgba(59, 130, 246, 0.05)) border-box;
   border: 1px solid transparent;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25), 0 6px 18px rgba(15, 23, 42, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 0 0 1px var(--board-ring-shadow);
   backdrop-filter: blur(18px) saturate(140%);
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -81,13 +81,14 @@
       </section>
 
       <div class="play-area">
-        <section
-          class="board"
-          id="board"
-          role="grid"
-          aria-label="Tic Tac Toe board"
-          aria-live="polite"
-        >
+        <div class="board-indicator" id="boardIndicator" data-role="board-indicator">
+          <section
+            class="board"
+            id="board"
+            role="grid"
+            aria-label="Tic Tac Toe board"
+            aria-live="polite"
+          >
           <button
             type="button"
             class="cell"
@@ -151,7 +152,8 @@
             data-index="8"
             aria-label="Row 3 column 3, empty"
           ></button>
-        </section>
+          </section>
+        </div>
 
         <footer class="controls">
           <div class="controls__group">

--- a/site/js/game.js
+++ b/site/js/game.js
@@ -150,6 +150,7 @@
     const statusApi = global.uiStatus;
     const statusElement = document.getElementById('statusMessage');
     const boardElement = document.getElementById('board');
+    const boardIndicatorElement = document.querySelector('[data-role="board-indicator"]');
     if (!boardElement) {
       return null;
     }
@@ -228,7 +229,22 @@
       }
     };
 
+    const updateBoardIndicator = (player) => {
+      if (!boardIndicatorElement) {
+        return;
+      }
+
+      boardIndicatorElement.classList.remove('is-turn-x', 'is-turn-o');
+
+      if (player === PLAYER_X) {
+        boardIndicatorElement.classList.add('is-turn-x');
+      } else if (player === PLAYER_O) {
+        boardIndicatorElement.classList.add('is-turn-o');
+      }
+    };
+
     const announceTurn = (player) => {
+      updateBoardIndicator(player);
       if (statusApi && typeof statusApi.setTurn === 'function') {
         statusApi.setTurn(player);
       } else {


### PR DESCRIPTION
## Summary
- wrap the tic-tac-toe grid in a new board indicator container that can host a glow effect
- add animated glow styles that shift colors for X and O turns using modifier classes
- update the turn announcement logic to toggle the indicator classes in sync with the current player

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68df8fd1fc28832890c319ba6b6a6d7e