### PR TITLE
feat: enable inline scoreboard name editing

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -687,6 +687,13 @@ button:focus-visible {
   transform: scale(1);
 }
 
+.scoreboard__player--editing {
+  box-shadow:
+    0 22px 48px rgba(15, 23, 42, 0.3),
+    0 0 0 2px rgba(255, 255, 255, 0.45),
+    0 0 28px var(--player-glow);
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .scoreboard__player--active::after {
     animation: scoreboard-glow 3s ease-in-out infinite;
@@ -743,9 +750,190 @@ button:focus-visible {
 }
 
 .scoreboard__name {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(8px, 2vw, 12px);
+  justify-self: start;
+  width: 100%;
+  padding: clamp(10px, 2.4vw, 14px) clamp(14px, 3vw, 18px);
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: 999px;
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.28) 70%, transparent);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
   font-weight: 600;
   font-size: clamp(1.05rem, 2.5vw, 1.2rem);
   letter-spacing: 0.01em;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.scoreboard__name:hover,
+.scoreboard__name:focus-visible {
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.42) 85%, transparent);
+  border-color: rgba(255, 255, 255, 0.72);
+  box-shadow:
+    0 18px 34px rgba(15, 23, 42, 0.26),
+    0 0 0 2px rgba(255, 255, 255, 0.32);
+}
+
+.scoreboard__name:focus-visible {
+  outline: none;
+}
+
+.scoreboard__player--x .scoreboard__name:focus-visible {
+  box-shadow:
+    0 18px 34px rgba(15, 23, 42, 0.26),
+    0 0 0 2px rgba(59, 130, 246, 0.55);
+}
+
+.scoreboard__player--o .scoreboard__name:focus-visible {
+  box-shadow:
+    0 18px 34px rgba(15, 23, 42, 0.26),
+    0 0 0 2px rgba(244, 63, 94, 0.55);
+}
+
+.scoreboard__name:active {
+  transform: translateY(1px);
+}
+
+.scoreboard__name-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(26px, 3vw, 30px);
+  height: clamp(26px, 3vw, 30px);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  font-size: clamp(0.8rem, 2vw, 0.95rem);
+  text-shadow: 0 0 10px var(--player-mark-glow);
+}
+
+.scoreboard__player--x .scoreboard__name-icon {
+  color: var(--player-mark-color);
+}
+
+.scoreboard__player--o .scoreboard__name-icon {
+  color: var(--player-mark-color);
+}
+
+.scoreboard__name-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scoreboard__name-hint {
+  font-size: clamp(0.55rem, 1.8vw, 0.65rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.scoreboard__name:hover .scoreboard__name-hint,
+.scoreboard__name:focus-visible .scoreboard__name-hint {
+  opacity: 0.88;
+  transform: translateY(0);
+}
+
+.scoreboard__name-editor {
+  grid-column: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.scoreboard__name-editor-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: 999px;
+  padding: 2px;
+  background: linear-gradient(
+    140deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(148, 163, 184, 0.18)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.scoreboard__name-editor-field:focus-within {
+  border-color: rgba(59, 130, 246, 0.58);
+  box-shadow: 0 20px 42px rgba(59, 130, 246, 0.32);
+}
+
+.scoreboard__player--o .scoreboard__name-editor-field:focus-within {
+  border-color: rgba(244, 63, 94, 0.62);
+  box-shadow: 0 20px 42px rgba(244, 63, 94, 0.32);
+}
+
+.scoreboard__name-editor-field.is-invalid {
+  border-color: rgba(244, 63, 94, 0.82);
+  box-shadow: 0 20px 42px rgba(244, 63, 94, 0.38);
+}
+
+.scoreboard__name-input {
+  flex: 1;
+  width: 100%;
+  padding: clamp(10px, 2.4vw, 14px) clamp(16px, 3vw, 20px);
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+  letter-spacing: 0.01em;
+  outline: none;
+}
+
+.scoreboard__name-input::placeholder {
+  color: color-mix(in srgb, currentColor 55%, transparent);
+  opacity: 0.85;
+}
+
+.scoreboard__name-input.is-invalid {
+  color: inherit;
+}
+
+.scoreboard__name-editor-error {
+  font-size: clamp(0.58rem, 1.9vw, 0.72rem);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(244, 63, 94, 0.95);
+  min-height: 1.1em;
+}
+
+.scoreboard__name-editor-error[aria-hidden="true"] {
+  visibility: hidden;
+}
+
+.scoreboard__name-editor-hint {
+  font-size: clamp(0.55rem, 1.8vw, 0.65rem);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--surface-strong) 72%, transparent);
 }
 
 .scoreboard__score {

--- a/site/index.html
+++ b/site/index.html
@@ -40,7 +40,23 @@
       >
         <article class="scoreboard__player scoreboard__player--x" data-player="X">
           <span class="scoreboard__mark" aria-hidden="true">X</span>
-          <span class="scoreboard__name" data-role="name" data-player="X">Player X</span>
+          <button
+            type="button"
+            class="scoreboard__name"
+            data-role="name"
+            data-player="X"
+            aria-controls="scoreboard-inline-editor-x"
+            aria-expanded="false"
+          >
+            <span class="scoreboard__name-icon" aria-hidden="true">✎</span>
+            <span class="scoreboard__name-text" data-role="name-label"
+              >Player X</span
+            >
+            <span class="scoreboard__name-hint" aria-hidden="true">Edit</span>
+            <span class="visually-hidden scoreboard__name-sr-hint"
+              >Activate to edit Player X's display name.</span
+            >
+          </button>
           <span class="scoreboard__score" data-player="X">
             <span id="score-label-x" class="visually-hidden">Wins for player X</span>
             <span
@@ -55,7 +71,23 @@
         </article>
         <article class="scoreboard__player scoreboard__player--o" data-player="O">
           <span class="scoreboard__mark" aria-hidden="true">O</span>
-          <span class="scoreboard__name" data-role="name" data-player="O">Player O</span>
+          <button
+            type="button"
+            class="scoreboard__name"
+            data-role="name"
+            data-player="O"
+            aria-controls="scoreboard-inline-editor-o"
+            aria-expanded="false"
+          >
+            <span class="scoreboard__name-icon" aria-hidden="true">✎</span>
+            <span class="scoreboard__name-text" data-role="name-label"
+              >Player O</span
+            >
+            <span class="scoreboard__name-hint" aria-hidden="true">Edit</span>
+            <span class="visually-hidden scoreboard__name-sr-hint"
+              >Activate to edit Player O's display name.</span
+            >
+          </button>
           <span class="scoreboard__score" data-player="O">
             <span id="score-label-o" class="visually-hidden">Wins for player O</span>
             <span

--- a/site/js/ui/settings.js
+++ b/site/js/ui/settings.js
@@ -27,6 +27,20 @@
     O: sanitiseName(names?.O ?? "", DEFAULT_NAMES.O),
   });
 
+  const globalNamespace =
+    typeof window !== "undefined"
+      ? (window.playerNameValidation = window.playerNameValidation || {})
+      : null;
+
+  if (globalNamespace) {
+    globalNamespace.DEFAULT_NAMES = DEFAULT_NAMES;
+    globalNamespace.NAME_PATTERN = NAME_PATTERN;
+    globalNamespace.INVALID_MESSAGE = INVALID_MESSAGE;
+    globalNamespace.isNameValid = isNameValid;
+    globalNamespace.sanitiseName = sanitiseName;
+    globalNamespace.normaliseNames = normaliseNames;
+  }
+
   const readPersistedNames = () => {
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -265,6 +279,11 @@
 
       return finalNames;
     };
+
+    if (globalNamespace) {
+      globalNamespace.applyAndPersistNames = (names, options) =>
+        applyAndPersistNames(names, options);
+    }
 
     attachValidation(fields.X, { onDirty: markDirty });
     attachValidation(fields.O, { onDirty: markDirty });

--- a/site/js/ui/status.js
+++ b/site/js/ui/status.js
@@ -3,12 +3,76 @@
     X: "Player X",
     O: "Player O",
   };
+  const FALLBACK_NAME_PATTERN =
+    /^[\p{L}\p{N}](?:[\p{L}\p{N}\s'.-]{0,23})$/u;
+  const FALLBACK_INVALID_MESSAGE =
+    "Use letters, numbers, spaces, apostrophes, periods or hyphens only.";
+
+  const fallbackSanitise = (value, fallback, pattern = FALLBACK_NAME_PATTERN) => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) {
+      return fallback;
+    }
+    return pattern.test(trimmed) ? trimmed : fallback;
+  };
+
+  const createFallbackNormaliser = (pattern, defaults) => (names = {}) => ({
+    X: fallbackSanitise(names?.X ?? "", defaults.X, pattern),
+    O: fallbackSanitise(names?.O ?? "", defaults.O, pattern),
+  });
+
+  const getNameUtils = () => {
+    const global =
+      typeof window !== "undefined" ? window.playerNameValidation : undefined;
+    const defaults = {
+      ...DEFAULT_NAMES,
+      ...(global && typeof global.DEFAULT_NAMES === "object"
+        ? global.DEFAULT_NAMES
+        : {}),
+    };
+    const pattern =
+      (global && global.NAME_PATTERN instanceof RegExp
+        ? global.NAME_PATTERN
+        : global?.NAME_PATTERN) || FALLBACK_NAME_PATTERN;
+    const isNameValid =
+      global && typeof global.isNameValid === "function"
+        ? global.isNameValid
+        : (value) => pattern.test(value);
+    const sanitiseName =
+      global && typeof global.sanitiseName === "function"
+        ? global.sanitiseName
+        : (value, fallback) => fallbackSanitise(value, fallback, pattern);
+    const normaliseNames =
+      global && typeof global.normaliseNames === "function"
+        ? global.normaliseNames
+        : createFallbackNormaliser(pattern, defaults);
+
+    return {
+      defaults,
+      pattern,
+      isNameValid,
+      sanitiseName,
+      normaliseNames,
+      invalidMessage:
+        global && typeof global.INVALID_MESSAGE === "string"
+          ? global.INVALID_MESSAGE
+          : FALLBACK_INVALID_MESSAGE,
+      applyAndPersistNames:
+        global && typeof global.applyAndPersistNames === "function"
+          ? global.applyAndPersistNames
+          : null,
+    };
+  };
 
   document.addEventListener("DOMContentLoaded", () => {
     const statusMessage = document.getElementById("statusMessage");
-    const nameElements = {
+    const nameButtons = {
       X: document.querySelector('[data-role="name"][data-player="X"]'),
       O: document.querySelector('[data-role="name"][data-player="O"]'),
+    };
+    const nameLabelElements = {
+      X: nameButtons.X?.querySelector(".scoreboard__name-text") ?? null,
+      O: nameButtons.O?.querySelector(".scoreboard__name-text") ?? null,
     };
     const scoreElements = {
       X: document.querySelector('[data-role="score"][data-player="X"]'),
@@ -21,20 +85,28 @@
 
     if (
       !statusMessage ||
-      !nameElements.X ||
-      !nameElements.O ||
+      !nameButtons.X ||
+      !nameButtons.O ||
+      !nameLabelElements.X ||
+      !nameLabelElements.O ||
       !scoreElements.X ||
       !scoreElements.O ||
       !playerCards.X ||
       !playerCards.O
     ) {
-      throw new Error("Unable to initialise status UI; required elements are missing.");
+      throw new Error(
+        "Unable to initialise status UI; required elements are missing."
+      );
     }
 
-    let playerNames = { ...DEFAULT_NAMES };
+    const initialUtils = getNameUtils();
+    let playerNames = initialUtils.normaliseNames(initialUtils.defaults);
     let scores = { X: 0, O: 0 };
     let currentPlayer = "X";
     let statusState = "turn"; // "turn" | "win" | "draw"
+    /** @type {null | { player: "X" | "O"; button: HTMLButtonElement; form: HTMLFormElement; input: HTMLInputElement; error: HTMLElement | null; field: HTMLElement | null; initialValue: string; }} */
+    let activeEditor = null;
+    let inlineCommitInProgress = false;
 
     const formatTurnMessage = (player) =>
       `${playerNames[player]} (${player}) to move`;
@@ -66,10 +138,74 @@
       applyVisualState();
     };
 
+    const updateNameDisplay = (player, value) => {
+      const label = nameLabelElements[player];
+      if (label) {
+        label.textContent = value;
+      }
+      const button = nameButtons[player];
+      if (button) {
+        button.title = `Edit name for ${value}`;
+      }
+    };
+
+    const setEditorError = (editor, message) => {
+      if (!editor || !editor.input) {
+        return;
+      }
+      const { input, field, error } = editor;
+      if (message) {
+        input.classList.add("is-invalid");
+        input.setAttribute("aria-invalid", "true");
+        field?.classList.add("is-invalid");
+        if (error) {
+          error.hidden = false;
+          error.setAttribute("aria-hidden", "false");
+          error.textContent = message;
+        }
+      } else {
+        input.classList.remove("is-invalid");
+        input.removeAttribute("aria-invalid");
+        field?.classList.remove("is-invalid");
+        if (error) {
+          error.hidden = true;
+          error.setAttribute("aria-hidden", "true");
+          error.textContent = "";
+        }
+      }
+    };
+
+    const validateInlineEditor = (editor) => {
+      if (!editor || !editor.input) {
+        return true;
+      }
+      const utils = getNameUtils();
+      const trimmed = editor.input.value.trim();
+      if (trimmed && !utils.isNameValid(trimmed)) {
+        setEditorError(editor, utils.invalidMessage);
+        return false;
+      }
+      setEditorError(editor, "");
+      return true;
+    };
+
     const applyNames = (names) => {
-      playerNames = { ...DEFAULT_NAMES, ...names };
-      nameElements.X.textContent = playerNames.X;
-      nameElements.O.textContent = playerNames.O;
+      const utils = getNameUtils();
+      const normalised = utils.normaliseNames({
+        ...utils.defaults,
+        ...playerNames,
+        ...(names ?? {}),
+      });
+      playerNames = normalised;
+      updateNameDisplay("X", normalised.X);
+      updateNameDisplay("O", normalised.O);
+      if (activeEditor && normalised[activeEditor.player]) {
+        activeEditor.initialValue = normalised[activeEditor.player];
+        if (activeEditor.input) {
+          activeEditor.input.value = normalised[activeEditor.player];
+        }
+        validateInlineEditor(activeEditor);
+      }
       refreshStatus();
     };
 
@@ -79,12 +215,218 @@
     };
 
     const setActivePlayerCard = (player) => {
-      (/** @type {("X"|"O")[]} */ (["X", "O"]))
+      (/** @type {("X" | "O")[]} */ (["X", "O"]))
         .filter((id) => playerCards[id])
         .forEach((id) => {
-          playerCards[id].classList.toggle("scoreboard__player--active", id === player);
+          playerCards[id].classList.toggle(
+            "scoreboard__player--active",
+            id === player
+          );
         });
     };
+
+    const closeInlineEditor = ({ focusButton = true } = {}) => {
+      if (!activeEditor) {
+        return;
+      }
+      const { button, form, player } = activeEditor;
+      if (form && form.parentElement) {
+        form.parentElement.removeChild(form);
+      }
+      if (button) {
+        button.hidden = false;
+        button.removeAttribute("aria-hidden");
+        button.setAttribute("aria-expanded", "false");
+        if (focusButton && typeof button.focus === "function") {
+          button.focus();
+        }
+      }
+      playerCards[player]?.classList.remove("scoreboard__player--editing");
+      activeEditor = null;
+    };
+
+    const cancelInlineEditor = ({ focusButton = true } = {}) => {
+      if (!activeEditor) {
+        return;
+      }
+      const editor = activeEditor;
+      if (editor.input) {
+        editor.input.value = editor.initialValue;
+      }
+      setEditorError(editor, "");
+      closeInlineEditor({ focusButton });
+    };
+
+    const commitInlineEdit = ({ restoreFocus = true } = {}) => {
+      if (!activeEditor) {
+        return false;
+      }
+      const editor = activeEditor;
+      if (!validateInlineEditor(editor)) {
+        editor.input.focus();
+        editor.input.select();
+        return false;
+      }
+      const utils = getNameUtils();
+      const defaultName = utils.defaults[editor.player];
+      const nextName = utils.sanitiseName(editor.input.value, defaultName);
+      if (nextName === editor.initialValue) {
+        closeInlineEditor({ focusButton: restoreFocus });
+        return true;
+      }
+      const nextNames = { ...playerNames, [editor.player]: nextName };
+      let finalNames = nextNames;
+      const applyAndPersist = utils.applyAndPersistNames;
+      inlineCommitInProgress = true;
+      try {
+        if (applyAndPersist) {
+          const result = applyAndPersist(nextNames, {
+            source: "scoreboard-inline",
+            propagate: true,
+            notify: true,
+            persist: true,
+            forceFormUpdate: true,
+          });
+          if (result && typeof result === "object") {
+            finalNames = result;
+          }
+        } else if (
+          typeof document !== "undefined" &&
+          typeof CustomEvent === "function"
+        ) {
+          document.dispatchEvent(
+            new CustomEvent("settings:players-updated", {
+              detail: {
+                names: { ...nextNames },
+                source: "scoreboard-inline",
+              },
+            })
+          );
+          finalNames = utils.normaliseNames(nextNames);
+        }
+      } catch (error) {
+        console.warn("Unable to apply inline player name update", error);
+      } finally {
+        inlineCommitInProgress = false;
+      }
+      closeInlineEditor({ focusButton: restoreFocus });
+      applyNames(finalNames);
+      return true;
+    };
+
+    const openInlineEditor = (player) => {
+      if (activeEditor?.player === player) {
+        return;
+      }
+      if (activeEditor) {
+        closeInlineEditor({ focusButton: false });
+      }
+      const button = nameButtons[player];
+      if (!button) {
+        return;
+      }
+      const utils = getNameUtils();
+      const currentValue = playerNames[player] ?? utils.defaults[player];
+      const form = document.createElement("form");
+      form.className = "scoreboard__name-editor";
+      form.noValidate = true;
+      form.dataset.player = player;
+      const editorId =
+        button.getAttribute("aria-controls") ||
+        `scoreboard-inline-editor-${player.toLowerCase()}`;
+      form.id = editorId;
+      button.setAttribute("aria-controls", editorId);
+      const field = document.createElement("div");
+      field.className = "scoreboard__name-editor-field";
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "scoreboard__name-input";
+      input.name = `scoreboardPlayer${player}`;
+      input.value = currentValue;
+      input.placeholder = utils.defaults[player];
+      input.maxLength = 24;
+      input.autocomplete = "off";
+      input.spellcheck = false;
+      input.setAttribute("data-player", player);
+      input.setAttribute("aria-label", `Player ${player} name`);
+      const hintId = `scoreboard-name-hint-${player.toLowerCase()}`;
+      const errorId = `scoreboard-name-error-${player.toLowerCase()}`;
+      input.setAttribute("aria-describedby", `${hintId} ${errorId}`.trim());
+      field.appendChild(input);
+      form.appendChild(field);
+      const error = document.createElement("p");
+      error.className = "scoreboard__name-editor-error";
+      error.id = errorId;
+      error.hidden = true;
+      error.setAttribute("aria-hidden", "true");
+      error.setAttribute("role", "alert");
+      error.setAttribute("aria-live", "polite");
+      form.appendChild(error);
+      const hint = document.createElement("p");
+      hint.className = "scoreboard__name-editor-hint";
+      hint.id = hintId;
+      hint.textContent = "Press Enter to save • Esc to cancel";
+      form.appendChild(hint);
+      button.insertAdjacentElement("afterend", form);
+      button.hidden = true;
+      button.setAttribute("aria-hidden", "true");
+      button.setAttribute("aria-expanded", "true");
+      playerCards[player]?.classList.add("scoreboard__player--editing");
+      activeEditor = {
+        player,
+        button,
+        form,
+        input,
+        error,
+        field,
+        initialValue: currentValue,
+      };
+      setEditorError(activeEditor, "");
+      input.focus();
+      input.select();
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        commitInlineEdit({ restoreFocus: true });
+      });
+
+      input.addEventListener("input", () => {
+        if (activeEditor?.input !== input) {
+          return;
+        }
+        validateInlineEditor(activeEditor);
+      });
+
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          cancelInlineEditor({ focusButton: true });
+        }
+      });
+
+      input.addEventListener("blur", () => {
+        if (activeEditor?.input !== input || inlineCommitInProgress) {
+          return;
+        }
+        window.setTimeout(() => {
+          if (!activeEditor || activeEditor.input !== input) {
+            return;
+          }
+          const activeEl = document.activeElement;
+          if (activeEl && activeEditor.form.contains(activeEl)) {
+            return;
+          }
+          commitInlineEdit({ restoreFocus: false });
+        }, 0);
+      });
+    };
+
+    nameButtons.X.addEventListener("click", () => {
+      openInlineEditor("X");
+    });
+    nameButtons.O.addEventListener("click", () => {
+      openInlineEditor("O");
+    });
 
     const api = {
       setTurn(player) {
@@ -171,7 +513,7 @@
       applyNames(detail.names);
     });
 
-    applyNames(DEFAULT_NAMES);
+    applyNames(playerNames);
     updateScoreDisplay();
     refreshStatus();
     setActivePlayerCard(currentPlayer);


### PR DESCRIPTION
## Summary
- turn scoreboard player names into accessible inline edit controls with focus hints and instructions
- style inline name editors with glass capsules, validation feedback, and editing highlights
- share player-name validation/persistence utilities so inline edits update settings and global state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fd29ad88328b3527bf171e9d61e