### PR TITLE
Add glass glyph rendering for board moves

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -92,6 +92,13 @@ select {
   --glow-accent: rgba(14, 165, 233, 0.26);
   --glow-ambient: rgba(15, 118, 110, 0.18);
   --glow-strong: rgba(79, 70, 229, 0.24);
+  --cell-x-color: #2563eb;
+  --cell-x-color-strong: #1d4ed8;
+  --cell-x-color-soft: #bfdbfe;
+  --cell-o-color: #dc2626;
+  --cell-o-color-strong: #b91c1c;
+  --cell-o-color-soft: #fecaca;
+  --cell-glyph-shadow: rgba(15, 23, 42, 0.42);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -127,6 +134,13 @@ select {
     --glow-accent: rgba(129, 140, 248, 0.32);
     --glow-ambient: rgba(45, 212, 191, 0.22);
     --glow-strong: rgba(30, 64, 175, 0.35);
+    --cell-x-color: #60a5fa;
+    --cell-x-color-strong: #3b82f6;
+    --cell-x-color-soft: #bfdbfe;
+    --cell-o-color: #f87171;
+    --cell-o-color-strong: #ef4444;
+    --cell-o-color-soft: #fee2e2;
+    --cell-glyph-shadow: rgba(2, 6, 23, 0.65);
   }
 }
 
@@ -907,6 +921,66 @@ button:focus-visible {
   background: radial-gradient(circle at 25% 20%, rgba(255, 255, 255, 0.45), transparent 55%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(148, 163, 184, 0));
   opacity: calc(var(--cell-reflection-opacity) * 0.75);
+}
+
+.cell__glyph {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 68%;
+  height: 68%;
+  pointer-events: none;
+}
+
+.cell__glyph::before {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border-radius: 22px;
+  opacity: 0;
+  transform: translateZ(0) scale(0.98);
+  transition: opacity 220ms ease, transform 220ms ease, box-shadow 240ms ease;
+  mix-blend-mode: screen;
+}
+
+.cell--x .cell__glyph::before {
+  opacity: 0.9;
+  transform: translateZ(0) scale(1);
+  background: radial-gradient(
+    circle at 50% 35%,
+    color-mix(in srgb, var(--cell-x-color-soft) 70%, transparent) 0%,
+    transparent 72%
+  );
+  box-shadow: 0 14px 26px color-mix(in srgb, var(--cell-x-color) 32%, transparent);
+}
+
+.cell--o .cell__glyph::before {
+  opacity: 0.9;
+  transform: translateZ(0) scale(1);
+  background: radial-gradient(
+    circle at 50% 35%,
+    color-mix(in srgb, var(--cell-o-color-soft) 70%, transparent) 0%,
+    transparent 72%
+  );
+  box-shadow: 0 14px 26px color-mix(in srgb, var(--cell-o-color) 32%, transparent);
+}
+
+.cell__icon {
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.cell--x .cell__icon--x {
+  filter: drop-shadow(0 10px 18px color-mix(in srgb, var(--cell-x-color) 28%, transparent))
+    drop-shadow(0 4px 10px var(--cell-glyph-shadow));
+}
+
+.cell--o .cell__icon--o {
+  filter: drop-shadow(0 10px 18px color-mix(in srgb, var(--cell-o-color) 28%, transparent))
+    drop-shadow(0 4px 10px var(--cell-glyph-shadow));
 }
 
 .cell:hover {

--- a/site/index.html
+++ b/site/index.html
@@ -94,63 +94,81 @@
             data-cell
             data-index="0"
             aria-label="Row 1 column 1, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="1"
             aria-label="Row 1 column 2, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="2"
             aria-label="Row 1 column 3, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="3"
             aria-label="Row 2 column 1, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="4"
             aria-label="Row 2 column 2, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="5"
             aria-label="Row 2 column 3, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="6"
             aria-label="Row 3 column 1, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="7"
             aria-label="Row 3 column 2, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
           <button
             type="button"
             class="cell"
             data-cell
             data-index="8"
             aria-label="Row 3 column 3, empty"
-          ></button>
+          >
+            <span class="cell__glyph" aria-hidden="true"></span>
+          </button>
         </section>
 
         <footer class="controls">


### PR DESCRIPTION
## Summary
- render X and O moves with inline SVG glyphs and preserve accessible labels
- add glyph containers to the board markup and gradients/glow styling for the pieces
- update board cell logic to manage glyph markup, ARIA labels, and data attributes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8fd29fdc8328b80d998780428cee