### PR TITLE
Enhance Tic Tac Toe hero title styling

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -149,6 +149,121 @@ body.page--game {
   overflow-x: hidden;
 }
 
+.page-title {
+  --badge-size: clamp(3.25rem, 3vw + 2.5rem, 4.25rem);
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(1rem, 2.2vw, 1.75rem);
+  align-items: center;
+  width: min(64rem, 100%);
+  padding: clamp(1.25rem, 2.5vw, 1.9rem) clamp(1.5rem, 3.5vw, 2.75rem);
+  border-radius: 32px;
+  background: color-mix(in srgb, var(--glass-surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 65%, transparent);
+  box-shadow: inset 0 1px 0 var(--glass-highlight), var(--glass-shadow);
+  overflow: hidden;
+  color: var(--text);
+}
+
+.page-title::before {
+  content: "";
+  position: absolute;
+  inset: -40% auto auto -12%;
+  width: clamp(14rem, 22vw, 18rem);
+  height: clamp(14rem, 22vw, 18rem);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(59, 130, 246, 0.3), transparent 72%);
+  filter: blur(0.5px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.page-title::after {
+  content: "";
+  position: absolute;
+  inset: auto -10% -45% auto;
+  width: clamp(16rem, 26vw, 22rem);
+  height: clamp(16rem, 28vw, 24rem);
+  border-radius: 50%;
+  background: radial-gradient(circle at 60% 60%, rgba(236, 72, 153, 0.25), transparent 68%);
+  filter: blur(1px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.page-title__badge {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: var(--badge-size);
+  height: var(--badge-size);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.82));
+  box-shadow: 0 18px 40px rgba(59, 130, 246, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  z-index: 1;
+}
+
+.page-title__badge img {
+  width: 62%;
+  height: 62%;
+  filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.15));
+}
+
+.page-title__text {
+  display: grid;
+  gap: clamp(0.2rem, 1vw, 0.6rem);
+  z-index: 1;
+}
+
+.page-title__eyebrow {
+  font-size: clamp(0.8rem, 0.8vw + 0.7rem, 1rem);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.page-title__headline {
+  font-size: clamp(2rem, 4vw + 1rem, 2.95rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--text) 0%, color-mix(in srgb, var(--accent) 68%, var(--text) 32%) 100%);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.page-title__subhead {
+  grid-column: 1 / -1;
+  font-size: clamp(0.95rem, 0.9vw + 0.8rem, 1.15rem);
+  color: var(--text-secondary);
+  max-width: 48ch;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .page-title {
+    grid-template-columns: 1fr;
+    justify-items: start;
+    text-align: left;
+  }
+
+  .page-title__badge {
+    width: clamp(2.75rem, 12vw, 3.5rem);
+    height: clamp(2.75rem, 12vw, 3.5rem);
+    border-radius: 20px;
+  }
+
+  .page-title__text {
+    gap: clamp(0.3rem, 1.4vw, 0.75rem);
+  }
+
+  .page-title__subhead {
+    max-width: none;
+  }
+}
+
 body.page--game::before,
 body.page--game::after {
   content: "";

--- a/site/index.html
+++ b/site/index.html
@@ -7,7 +7,19 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body class="page page--game">
-    <h1>Tic Tac Toe</h1>
+    <h1 class="page-title" aria-describedby="pageTitleSubtitle">
+      <span class="page-title__badge" aria-hidden="true">
+        <img src="assets/icon-handshake.svg" alt="" />
+      </span>
+      <span class="page-title__text">
+        <span class="page-title__eyebrow">Interactive match center</span>
+        <span class="page-title__headline">Tic Tac Toe Showdown</span>
+      </span>
+      <span id="pageTitleSubtitle" class="page-title__subhead">
+        Challenge friends, monitor live scoreboards, and personalize every round
+        from one polished control hub.
+      </span>
+    </h1>
     <main class="app-shell" role="application" aria-label="Tic Tac Toe">
       <header class="toolbar">
         <p class="toolbar__title">


### PR DESCRIPTION
## Summary
- redesign the game header to include a badge, headline, and descriptive subtext for a more polished presentation
- add responsive styling, gradients, and layout rules to support the new interactive title module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df904bc0508328a3a5f244d5bd8490