### PR TITLE
Fix scoreboard layout clipping

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -504,10 +504,11 @@ button:focus-visible {
 .scoreboard {
   position: relative;
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 0;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(16px, 2vw, 24px);
   width: 100%;
-  padding: clamp(12px, 3vw, 24px);
+  padding: clamp(16px, 3vw, 24px);
+  flex: none;
   border-radius: 24px;
   background: linear-gradient(
     140deg,
@@ -550,8 +551,6 @@ button:focus-visible {
 @media (min-width: 560px) {
   .scoreboard {
     grid-template-columns: repeat(2, minmax(220px, 1fr));
-    gap: clamp(18px, 4vw, 28px);
-    justify-content: center;
     align-content: center;
   }
 }
@@ -578,12 +577,13 @@ button:focus-visible {
   --player-glow: rgba(59, 130, 246, 0.68);
   --player-mark-glow: rgba(59, 130, 246, 0.58);
   position: relative;
-  z-index: 0;
+  z-index: 1;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: clamp(12px, 3vw, 18px);
-  padding: clamp(16px, 3.5vw, 24px) clamp(18px, 5vw, 28px);
+  padding: clamp(18px, 4vw, 28px) clamp(20px, 5vw, 32px);
+  min-height: clamp(72px, 18vw, 110px);
   border-radius: 20px;
   color: var(--surface-strong);
   background: linear-gradient(
@@ -746,6 +746,8 @@ button:focus-visible {
   font-weight: 600;
   font-size: clamp(1.05rem, 2.5vw, 1.2rem);
   letter-spacing: 0.01em;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .scoreboard__score {


### PR DESCRIPTION
## Summary
- prevent the scoreboard section from shrinking so player cards stay fully visible
- increase spacing and minimum height on each player card for better readability on all breakpoints
- allow long player names to wrap instead of overflowing their column

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df905a530083289f87eed8b8c4b8c3