### PR TITLE
Improve history cloning fallback for older environments

### DIFF
--- a/site/js/core/history.js
+++ b/site/js/core/history.js
@@ -6,9 +6,27 @@
     capacity: Infinity,
   };
 
+  const cloneUsingStructuredClone =
+    typeof global.structuredClone === 'function'
+      ? (value) => global.structuredClone(value)
+      : null;
+
+  let cloneUsingV8 = null;
+  if (!cloneUsingStructuredClone && typeof module !== 'undefined' && module.exports) {
+    try {
+      const { serialize, deserialize } = require('node:v8');
+      cloneUsingV8 = (value) => deserialize(serialize(value));
+    } catch (error) {
+      // Ignore – fall back to JSON cloning below.
+    }
+  }
+
   function defaultClone(value) {
-    if (typeof structuredClone === 'function') {
-      return structuredClone(value);
+    if (cloneUsingStructuredClone) {
+      return cloneUsingStructuredClone(value);
+    }
+    if (cloneUsingV8) {
+      return cloneUsingV8(value);
     }
     return JSON.parse(JSON.stringify(value));
   }


### PR DESCRIPTION
## Summary
- add environment-aware clone helpers so history state cloning works without structuredClone
- prefer Node's v8 serializer as the primary fallback before JSON cloning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df9b8d00548328b53d86eedb454924