### PR TITLE
fix: increase breathing room near the game board

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -365,6 +365,7 @@ body.page--game {
   align-items: center;
   width: min(64rem, 100%);
   padding: clamp(1.25rem, 2.5vw, 1.9rem) clamp(1.5rem, 3.5vw, 2.75rem);
+  padding-block-end: clamp(1.9rem, 3vw, 3rem);
   border-radius: 32px;
   background: color-mix(in srgb, var(--glass-surface) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--glass-border) 65%, transparent);
@@ -671,6 +672,7 @@ button:focus-visible {
   border: 1px solid var(--glass-border);
   border-radius: clamp(1.25rem, 1.5vw + 1rem, 2rem);
   padding: clamp(1.75rem, 2.2vw + 1.5rem, 3.5rem);
+  padding-block-end: clamp(2.5rem, 2.5vw + 2rem, 4rem);
   box-shadow: var(--glass-shadow);
   overflow: hidden;
   z-index: 0;
@@ -1480,6 +1482,7 @@ button:focus-visible {
   gap: 24px;
   align-content: space-between;
   min-height: clamp(360px, 52vh, 520px);
+  padding-block-end: clamp(1.5rem, 2vw, 2.5rem);
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- add extra bottom padding to the hero card so the subtitle no longer crowds the border
- expand the app shell and play area bottom padding to keep controls and board away from the edge

## Testing
- npm run serve

------
https://chatgpt.com/codex/tasks/task_e_68dfa1dc51708328b2bda5dc20fd59f0