### PR TITLE
Adjust board spacing and disable selection highlights

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -39,6 +39,14 @@ body {
     sans-serif;
   background: var(--surface, #ffffff);
   color: var(--text, #111827);
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}
+
+*::selection {
+  background: transparent;
+  color: inherit;
 }
 
 img,
@@ -55,6 +63,12 @@ button,
 textarea,
 select {
   font: inherit;
+}
+
+input,
+textarea {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 :root {
@@ -347,10 +361,10 @@ body.page--game {
   flex-direction: column;
   align-items: center;
   padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem)
-    clamp(3.5rem, 8vw, 5.5rem);
+    clamp(4.75rem, 9vw, 7.5rem);
   box-sizing: border-box;
   gap: clamp(1.75rem, 4vw, 3rem);
-  min-height: 100%;
+  min-height: 100vh;
   position: relative;
   isolation: isolate;
   overflow-x: hidden;
@@ -672,7 +686,7 @@ button:focus-visible {
   border: 1px solid var(--glass-border);
   border-radius: clamp(1.25rem, 1.5vw + 1rem, 2rem);
   padding: clamp(1.75rem, 2.2vw + 1.5rem, 3.5rem);
-  padding-block-end: clamp(2.5rem, 2.5vw + 2rem, 4rem);
+  padding-block-end: clamp(3.25rem, 3vw + 2.25rem, 4.75rem);
   box-shadow: var(--glass-shadow);
   overflow: hidden;
   z-index: 0;
@@ -1482,7 +1496,7 @@ button:focus-visible {
   gap: 24px;
   align-content: space-between;
   min-height: clamp(360px, 52vh, 520px);
-  padding-block-end: clamp(1.5rem, 2vw, 2.5rem);
+  padding-block-end: clamp(2.25rem, 3vw, 3.5rem);
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- add global selection guardrails to prevent text highlighting on the game surface while keeping form fields editable
- increase game layout padding to prevent the board and controls from being cropped on smaller viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfa5977f888328bde71e42864616b3