### PR TITLE
Fix GitHub Pages workflow permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- allow the Pages workflow to check out the repository by restoring `contents: read` permissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfaa6878088328813301fa06fc50ab