### PR TITLE
Fix GitHub Pages workflow build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,17 +27,10 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
-        run: echo "No dependencies to install"
+        run: npm ci
 
-      - name: Run tests
-        run: echo "No tests to run"
-
-      - name: Build site artifact
-        run: |
-          set -euo pipefail
-          rm -rf dist
-          mkdir -p dist
-          cp -R site/. dist/
+      - name: Run build
+        run: npm run build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This modular structure keeps the board responsive, enables drop-in enhancements 
 ## Deployment
 1. Build the distributable bundle with `npm run build` (or rely on the automated Pages workflow).
 2. Optionally serve `dist/` locally to verify the static output.
-3. Push to `main` to trigger `.github/workflows/pages.yml`, which stages `dist/` and deploys it to GitHub Pages automatically.
+3. Push to `main` to trigger `.github/workflows/pages.yml`, which runs `npm run build` to populate `dist/` before deploying it to GitHub Pages automatically.
 
 ## Documentation and support
 - Review the [Code of Conduct](CODE_OF_CONDUCT.md) and [Contributing Guide](CONTRIBUTING.md) for expectations and onboarding details.


### PR DESCRIPTION
## What changed
- Update the GitHub Pages workflow to install npm dependencies and run the existing `npm run build` script before packaging the artifact.
- Document the deployment workflow so contributors know it executes the build script prior to publishing.

## Why
- Ensures the published site is generated by the same build pipeline used locally, preventing regressions when the build script gains additional logic.

## Testing notes
- [ ] Unit tests added or updated
- [ ] E2E ran green in CI

Verified locally with `npm run build` and `npm test`.

## A11y checklist
- [ ] Focus order verified
- [ ] ARIA roles and labels present
- [ ] Color contrast validated

------
https://chatgpt.com/codex/tasks/task_e_68dfaaa5ed688328a30a96e6b89496ba