### PR TITLE
fix(ci): stub e2e ci script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Explore the production build on GitHub Pages: **https://alex-unnippillil.github.
 | `npm run dev` | Serves the contents of `site/` locally using `http-server`. |
 | `npm run build` | Copies `site/` into `dist/`, mirroring the GitHub Pages packaging step. |
 | `npm run test` | Executes the Node-based unit tests located in `tests/`. |
+| `npm run e2e` | Placeholder stub for end-to-end tests; currently prints a status message. |
+| `npm run e2e:ci` | CI alias that proxies to `npm run e2e` so the workflow succeeds until real tests ship. |
 | `npm run lint` | Reserved for future lint rules (no-op today). |
 | `npm run deploy` | Matches the Pages workflow for manual deployments when needed. |
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "npm run serve",
     "lint": "echo \"No lint script configured\"",
     "test": "node --test tests/unit",
-    "e2e": "echo \"No end-to-end tests configured\""
+    "e2e": "echo \"No end-to-end tests configured\"",
+    "e2e:ci": "npm run e2e"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.1",


### PR DESCRIPTION
## Summary
- add an `e2e:ci` npm script that delegates to the existing e2e placeholder so the workflow stops failing
- document both e2e commands in the project scripts table for clarity

## Testing
- npm run e2e:ci
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfaae5341c83288fff53acfd80bfec