### PR TITLE
Fix reduced motion styling for the game board

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -2169,7 +2169,7 @@ dialog.is-closing::backdrop {
   .toolbar__actions .button,
   .status,
   .board,
-  .board::after {
+  .board::after,
   .segmented-control__label,
   .swatch__content,
   .swatch__visual {


### PR DESCRIPTION
## What changed
- Corrected the reduced-motion selector list so the board and other UI elements correctly disable transitions when users prefer reduced motion.

## Why
- A stray `{` broke the selector group, preventing the board from respecting reduced-motion preferences.

## Screenshots
- ![Board view with reduced motion preference](browser:/invocations/xnbkmfkd/artifacts/artifacts/board-reduced-motion.png)

## Testing notes
- [x] `npm test`
- [x] `npm run build`

## A11y checklist
- [ ] Focus order verified
- [x] ARIA roles and labels present
- [x] Color contrast validated


------
https://chatgpt.com/codex/tasks/task_e_68dfabc56d5c83289631efc2d729fb22