### PR TITLE
chore: remove hero subtitle text

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,17 +10,13 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body class="page page--game">
-    <h1 class="page-title" aria-describedby="pageTitleSubtitle">
+    <h1 class="page-title">
       <span class="page-title__badge" aria-hidden="true">
         <img src="assets/icon-handshake.svg" alt="" />
       </span>
       <span class="page-title__text">
         <span class="page-title__eyebrow">Interactive match center</span>
         <span class="page-title__headline">Tic Tac Toe Showdown</span>
-      </span>
-      <span id="pageTitleSubtitle" class="page-title__subhead">
-        Challenge friends, monitor live scoreboards, and personalize every round
-        from one polished control hub.
       </span>
     </h1>
     <main class="app-shell" role="application" aria-label="Tic Tac Toe">

--- a/site/index.html
+++ b/site/index.html
@@ -7,17 +7,13 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body class="page page--game">
-    <h1 class="page-title" aria-describedby="pageTitleSubtitle">
+    <h1 class="page-title">
       <span class="page-title__badge" aria-hidden="true">
         <img src="assets/icon-handshake.svg" alt="" />
       </span>
       <span class="page-title__text">
         <span class="page-title__eyebrow">Interactive match center</span>
         <span class="page-title__headline">Tic Tac Toe Showdown</span>
-      </span>
-      <span id="pageTitleSubtitle" class="page-title__subhead">
-        Challenge friends, monitor live scoreboards, and personalize every round
-        from one polished control hub.
       </span>
     </h1>
     <main class="app-shell" role="application" aria-label="Tic Tac Toe">


### PR DESCRIPTION
## Summary
- remove the hero subtitle text from the landing page markup
- keep the root index and site entry point in sync

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e00d3537448328911d521bc045887e