### PR TITLE
Update sitemap with canonical GitHub Pages URL

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>/</loc>
+    <loc>https://alex-unnippillil.github.io/tictactoe/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- replace the sitemap entry with the absolute GitHub Pages URL so crawlers resolve the published site correctly

## Testing
- npx --yes sitemap-validator -l http://127.0.0.1:8000/sitemap.xml -c 200

------
https://chatgpt.com/codex/tasks/task_e_68e00e824bd08328af648692262cde71