### PR TITLE
Increase confetti celebration duration

### DIFF
--- a/site/js/ui/effects.js
+++ b/site/js/ui/effects.js
@@ -86,7 +86,7 @@
     }, duration);
   };
 
-  const playConfetti = ({ duration = 1800, particleCount = 140, tone = 'x' } = {}) => {
+  const playConfetti = ({ duration = 3200, particleCount = 140, tone = 'x' } = {}) => {
     if (shouldReduceMotion()) {
       return Promise.resolve();
     }


### PR DESCRIPTION
## Summary
- extend the default confetti animation duration so the celebration lasts longer after a win

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00f02f3e883289d295dce3d8f2480