### PR TITLE
feat: streamline match toolbar

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -767,27 +767,23 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-sm);
+  gap: var(--space-xs);
   flex-wrap: wrap;
-  padding: clamp(0.85rem, 0.8vw + 0.65rem, 1.25rem)
-    clamp(1.1rem, 1.2vw + 0.8rem, 2rem);
-  border-radius: 24px;
-  background: var(--glass-overlay);
-  background: color-mix(in srgb, var(--surface) 78%, transparent);
-  border: 1px solid var(--glass-border);
-  border: 1px solid color-mix(in srgb, var(--surface-strong) 14%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-    0 18px 44px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  padding: clamp(0.65rem, 0.6vw + 0.5rem, 0.95rem)
+    clamp(0.85rem, 0.9vw + 0.6rem, 1.5rem);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface) 62%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-strong) 10%, transparent);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
 
 .toolbar__title {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2xs);
-  font-size: clamp(1.1rem, 2vw + 1rem, 1.85rem);
+  gap: var(--space-3xs);
+  font-size: clamp(1rem, 1.5vw + 0.9rem, 1.45rem);
   font-weight: 700;
   color: var(--text);
   letter-spacing: -0.015em;
@@ -798,8 +794,8 @@ button:focus-visible {
 }
 
 .toolbar__title-icon {
-  width: 1.75em;
-  height: 1.75em;
+  width: 1.4em;
+  height: 1.4em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -812,13 +808,13 @@ button:focus-visible {
 
 .toolbar__actions {
   display: flex;
-  gap: var(--space-xs);
+  gap: var(--space-2xs);
   flex-wrap: wrap;
   justify-content: flex-end;
 }
 
 .toolbar__actions .button {
-  min-width: clamp(8rem, 8vw + 4rem, 11rem);
+  min-width: clamp(6.5rem, 6vw + 3rem, 8.5rem);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- simplify the match toolbar styling to better align with the game's minimal aesthetic
- reduce typography, padding, and button widths so the header occupies less space while keeping readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b3d7bc908328aca484318a22fef8