### PR TITLE
fix: shrink toolbar heading

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -769,8 +769,8 @@ button:focus-visible {
   justify-content: space-between;
   gap: var(--space-sm);
   flex-wrap: wrap;
-  padding: clamp(0.85rem, 0.8vw + 0.65rem, 1.25rem)
-    clamp(1.1rem, 1.2vw + 0.8rem, 2rem);
+  padding: clamp(0.6375rem, 0.6vw + 0.4875rem, 0.9375rem)
+    clamp(0.825rem, 0.9vw + 0.6rem, 1.5rem);
   border-radius: 24px;
   background: var(--glass-overlay);
   background: color-mix(in srgb, var(--surface) 78%, transparent);
@@ -787,7 +787,7 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2xs);
-  font-size: clamp(1.1rem, 2vw + 1rem, 1.85rem);
+  font-size: clamp(0.825rem, 1.5vw + 0.75rem, 1.3875rem);
   font-weight: 700;
   color: var(--text);
   letter-spacing: -0.015em;


### PR DESCRIPTION
## Summary
- shrink the toolbar heading font size to make the "Friendly match" label 25% smaller
- reduce the toolbar padding values by 25% so the container occupies less space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b4f77f1483289e1c433d11545642