### PR TITLE
chore: wire real lint and Playwright checks into scripts and docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-node_modules/
-dist/
-build/
-coverage/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ This project is built with vanilla HTML, CSS, and JavaScript. Please adhere to t
 ## Local development workflow
 
 ### Prerequisites
-- [Node.js](https://nodejs.org/) 18 or newer (for linting/formatting commands).
+- [Node.js](https://nodejs.org/) 20 or newer (matches CI and local tooling expectations).
 - A modern web browser for manual testing.
 
 ### Running the site locally
@@ -79,13 +79,13 @@ The repository ships with automated coverage that you are expected to keep green
 
   Run the suite whenever you touch the game engine, history persistence, or add new logic that should be regression-proof. Add new `.test.js`/`.spec.js` files alongside the existing ones in `tests/unit/` so CI picks them up automatically.
 
-- **Playwright E2E scaffolding (`tests/e2e/`)** – There is a starter spec, `keyboard.spec.ts`, that exercises keyboard navigation and announcements. It expects the static site to be served locally (for example with `npm run serve`). When you introduce new interaction flows, extend this directory with additional Playwright specs and wire up the `npm run e2e`/`npm run e2e:ci` scripts as needed so contributors and CI can execute them consistently.
+- **Playwright E2E keyboard checks (`tests/e2e/`)** – `keyboard.spec.ts` exercises keyboard navigation and announcements. Run `npm run e2e` for local execution (Playwright starts the web server via `playwright.config.ts`) and `npm run e2e:ci` for the CI-safe server+test workflow.
 
 If you add new automated checks, update this section with instructions and ensure they are runnable without extra secrets or services.
 
 ## Continuous integration & deployment
 
-- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs `npm test`, and expects an `npm run e2e:ci` command to exercise the Playwright specs. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
+- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs `npm run lint`, `npm test`, and `npm run e2e:ci` to exercise Playwright headlessly. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
 - Merges to `main` automatically trigger the GitHub Pages deployment pipeline. To keep deployments healthy, confirm that `index.html` and any assets you add load correctly when served from the repository root, and avoid introducing references to private or server-side resources.
 - If a deployment fails, investigate the CI logs and open a follow-up PR with a fix or revert.
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ The live app is structured to make every round easy to follow:
 | `npm run dev` | Serves the contents of `site/` locally using `http-server`. |
 | `npm run build` | Copies `site/` into `dist/`, mirroring the GitHub Pages packaging step. |
 | `npm run test` | Executes the Node-based unit tests located in `tests/`. |
-| `npm run e2e` | Placeholder stub for end-to-end tests; currently prints a status message. |
-| `npm run e2e:ci` | CI alias that proxies to `npm run e2e` so the workflow succeeds until real tests ship. |
-| `npm run lint` | Reserved for future lint rules (no-op today). |
+| `npm run e2e` | Runs Playwright against `tests/e2e/keyboard.spec.ts` using the shared Playwright config. |
+| `npm run e2e:ci` | Starts the static server and runs the Playwright keyboard suite with CI-safe retries. |
+| `npm run lint` | Runs ESLint checks across browser scripts and build/test JavaScript files. |
 | `npm run deploy` | Matches the Pages workflow for manual deployments when needed. |
 
 ## Repository layout
@@ -103,6 +103,8 @@ This modular structure keeps the board responsive, enables drop-in enhancements 
 
 ## Testing and quality
 - **Unit tests:** `npm run test` runs the Node-based suite under `tests/`.
+- **Linting:** `npm run lint` validates JavaScript in `site/js/`, `scripts/`, and `tests/`.
+- **E2E keyboard regression:** `npm run e2e` runs `tests/e2e/keyboard.spec.ts` with Playwright, and `npm run e2e:ci` wraps the same suite with a server startup flow for CI.
 - **Continuous integration:** [`ci.yml`](.github/workflows/ci.yml) validates every push, and [`static.yml`](.github/workflows/static.yml) is reserved for additional static analysis.
 - **Lighthouse audits:** [`lighthouse.yml`](.github/workflows/lighthouse.yml) executes `npx lhci autorun` against the deployed site, publishing an artifact named **`lighthouse-report`** with the latest performance, accessibility, best-practices, and SEO scores.
 - **Manual smoke testing:** Validate local changes in `npm run dev` by playing through win, draw, and reset paths to ensure focus states, narration, and persistence continue to behave as documented.
@@ -120,4 +122,3 @@ This modular structure keeps the board responsive, enables drop-in enhancements 
 ## License
 This project is licensed under the [MIT License](LICENSE).
 <img width="1000" height="1318" alt="image" src="https://github.com/user-attachments/assets/f83d8743-8b3a-4de9-b3e1-806dbd5bd142" />
-

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,39 @@
+module.exports = [
+  {
+    ignores: ['node_modules/**', 'dist/**', 'build/**', 'coverage/**']
+  },
+  {
+    files: ['site/js/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly'
+      }
+    },
+    rules: {
+      semi: ['error', 'always'],
+      'no-unused-vars': 'warn',
+      eqeqeq: 'warn',
+      curly: ['error', 'all']
+    }
+  },
+  {
+    files: ['scripts/**/*.mjs', 'tests/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        process: 'readonly'
+      }
+    },
+    rules: {
+      semi: ['error', 'always'],
+      'no-unused-vars': 'warn',
+      eqeqeq: 'warn',
+      curly: ['error', 'all']
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "build": "node scripts/build.mjs",
     "deploy": "npm run build",
     "start": "npm run serve",
-    "lint": "echo \"No lint script configured\"",
+    "lint": "eslint \"site/js/**/*.js\" \"scripts/**/*.mjs\" \"tests/**/*.js\"",
     "test": "node --test tests/unit",
-    "e2e": "echo \"No end-to-end tests configured\"",
-    "e2e:ci": "npm run e2e"
+    "e2e": "playwright test tests/e2e/keyboard.spec.ts",
+    "e2e:ci": "start-server-and-test \"npm run serve -- --port 4173 --host 127.0.0.1\" http://127.0.0.1:4173 \"playwright test tests/e2e/keyboard.spec.ts --retries=2\""
   },
   "devDependencies": {
     "@playwright/test": "^1.55.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true
+  },
+  webServer: {
+    command: 'npx http-server site -p 4173 -a 127.0.0.1',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  }
+});


### PR DESCRIPTION
### Motivation

- Replace stubbed scripts with real checks so lint and end-to-end regressions are caught by local runs and CI. 
- Provide a Playwright configuration that starts the static site deterministically and enables CI-friendly retries and reporting. 
- Migrate to ESLint v9 flat config so `npm run lint` performs a real pass against browser and build/test JS files.

### Description

- Updated `package.json` scripts so `lint` runs ESLint against `site/js/**/*.js`, `scripts/**/*.mjs`, and `tests/**/*.js`, `e2e` runs `playwright test tests/e2e/keyboard.spec.ts`, and `e2e:ci` uses `start-server-and-test` to boot the site and run Playwright with retries. 
- Added `playwright.config.ts` with `webServer` that serves `site/`, a fixed `baseURL`, and CI-aware `retries` and `reporter` settings. 
- Added `eslint.config.js` (flat config) and removed the deprecated `.eslintignore` so ESLint v9 can load configuration correctly. 
- Updated `README.md` and `CONTRIBUTING.md` to document the new scripts and require Node.js 20+; verified the existing CI workflow (`.github/workflows/ci.yml`) invokes the new script entrypoints.

### Testing

- Ran `npm run lint`, which now executes ESLint and completed with warnings (no blocking errors in the final configuration). 
- Ran `npm test`, and the Node unit suite in `tests/unit` passed (all tests OK). 
- Attempted `npm run e2e` locally and Playwright failed due to missing browser binaries in this environment; CI installs browsers via `npx playwright install --with-deps` before running `npm run e2e:ci` so the suite will run headlessly on CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c9fca58832882e4fc53285bdf8d)