### PR TITLE
docs: align README/CONTRIBUTING/docs with actual npm scripts and CI behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,17 +38,31 @@ This project is built with vanilla HTML, CSS, and JavaScript. Please adhere to t
 ## Local development workflow
 
 ### Prerequisites
-- [Node.js](https://nodejs.org/) 18 or newer (for linting/formatting commands).
+- [Node.js](https://nodejs.org/) 20 or newer.
 - A modern web browser for manual testing.
 
 ### Running the site locally
-Because this is a static site, the simplest approach is to open `index.html` directly in your browser. If you prefer a local server (recommended for accurate GitHub Pages parity), you can run:
+Serve the same `site/` directory that GitHub Pages deploys:
 
 ```bash
-npx serve .
+npm run dev
 ```
 
-Then visit `http://localhost:3000`.
+`npm run dev` is an alias for `npm run serve`, and `serve` runs `npx http-server site`.
+
+### Script reference (`package.json`)
+
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Alias for `npm run serve`. |
+| `npm run serve` | Serves `site/` using `npx http-server site`. |
+| `npm run build` | Copies `site/` into `dist/` via `scripts/build.mjs`. |
+| `npm run deploy` | Alias for `npm run build`. |
+| `npm run start` | Alias for `npm run serve`. |
+| `npm run lint` | Placeholder that prints `No lint script configured`. |
+| `npm run test` | Runs `node --test tests/unit`. |
+| `npm run e2e` | Placeholder that prints `No end-to-end tests configured`. |
+| `npm run e2e:ci` | Runs `npm run e2e`. |
 
 ### Linting and formatting
 Editor defaults are captured in the repository's [`.editorconfig`](./.editorconfig), which enforces UTF-8 encoding, LF line endings, final newlines, and two-space indentation for web assets and config files. Most modern editors detect this automatically.
@@ -69,23 +83,26 @@ Feel free to add a `.prettierrc` file in a separate pull request if you need cus
 
 ### Tests and end-to-end checks
 
-The repository ships with automated coverage that you are expected to keep green:
+Run the project quality commands from the repository root:
 
-- **Unit tests (`tests/unit/`)** – These run with Node's built-in test runner via Jest-style specs. The current suite covers the AI decision tree (`ai.spec.js`), move history helpers (`history.test.js`), and the opening move heuristics (`minimax-first-move.test.js`). Execute all unit tests locally with:
+```bash
+npm run test
+npm run lint
+npm run e2e
+```
 
-  ```bash
-  npm run test
-  ```
+Current behavior of those scripts:
 
-  Run the suite whenever you touch the game engine, history persistence, or add new logic that should be regression-proof. Add new `.test.js`/`.spec.js` files alongside the existing ones in `tests/unit/` so CI picks them up automatically.
+- `npm run test` runs the Node test runner on `tests/unit`.
+- `npm run lint` currently prints `No lint script configured` (placeholder).
+- `npm run e2e` currently prints `No end-to-end tests configured` (placeholder).
+- `npm run e2e:ci` is a CI alias that runs `npm run e2e`.
 
-- **Playwright E2E scaffolding (`tests/e2e/`)** – There is a starter spec, `keyboard.spec.ts`, that exercises keyboard navigation and announcements. It expects the static site to be served locally (for example with `npm run serve`). When you introduce new interaction flows, extend this directory with additional Playwright specs and wire up the `npm run e2e`/`npm run e2e:ci` scripts as needed so contributors and CI can execute them consistently.
-
-If you add new automated checks, update this section with instructions and ensure they are runnable without extra secrets or services.
+Even though lint and e2e are placeholders today, keep them runnable in local validation so CI and local workflows stay aligned.
 
 ## Continuous integration & deployment
 
-- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs `npm test`, and expects an `npm run e2e:ci` command to exercise the Playwright specs. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
+- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs `npm run lint`, `npm run test`, and `npm run e2e:ci` to mirror the package scripts defined in this repository. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
 - Merges to `main` automatically trigger the GitHub Pages deployment pipeline. To keep deployments healthy, confirm that `index.html` and any assets you add load correctly when served from the repository root, and avoid introducing references to private or server-side resources.
 - If a deployment fails, investigate the CI logs and open a follow-up PR with a fix or revert.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The live app is structured to make every round easy to follow:
 - **Settings integration:** Auxiliary UI modules (see `site/js/ui/`) listen for state changes to handle preferences such as player names and to broadcast announcements to the shared status area.
 
 ## Getting started
-> **Prerequisites:** Node.js 20+ and npm 9+ (aligned with the CI environment).
+> **Prerequisites:** Node.js 20 or newer (npm ships with Node and is used for all project scripts).
 
 1. Install dependencies:
    ```bash
@@ -54,7 +54,7 @@ The live app is structured to make every round easy to follow:
    ```bash
    npm run dev
    ```
-   Changes inside `site/` hot-reload instantly while you iterate.
+   This serves the `site/` directory—the same static assets deployed by GitHub Pages.
 3. When you are ready to publish locally, build the static bundle:
    ```bash
    npm run build
@@ -69,13 +69,15 @@ The live app is structured to make every round easy to follow:
 ## Project scripts
 | Command | Description |
 | --- | --- |
-| `npm run dev` | Serves the contents of `site/` locally using `http-server`. |
-| `npm run build` | Copies `site/` into `dist/`, mirroring the GitHub Pages packaging step. |
-| `npm run test` | Executes the Node-based unit tests located in `tests/`. |
-| `npm run e2e` | Placeholder stub for end-to-end tests; currently prints a status message. |
-| `npm run e2e:ci` | CI alias that proxies to `npm run e2e` so the workflow succeeds until real tests ship. |
-| `npm run lint` | Reserved for future lint rules (no-op today). |
-| `npm run deploy` | Matches the Pages workflow for manual deployments when needed. |
+| `npm run dev` | Alias for `npm run serve`. |
+| `npm run serve` | Serves `site/` locally using `npx http-server site`. |
+| `npm run build` | Copies `site/` into `dist/` using `scripts/build.mjs`. |
+| `npm run deploy` | Alias for `npm run build`. |
+| `npm run start` | Alias for `npm run serve`. |
+| `npm run lint` | Prints `No lint script configured` (placeholder script). |
+| `npm run test` | Runs Node's built-in test runner against `tests/unit`. |
+| `npm run e2e` | Prints `No end-to-end tests configured` (placeholder script). |
+| `npm run e2e:ci` | CI alias for `npm run e2e`. |
 
 ## Repository layout
 | Path | Purpose |
@@ -102,10 +104,11 @@ This modular structure keeps the board responsive, enables drop-in enhancements 
 - **Reduced-risk persistence:** Storage reads and writes are wrapped in guards to avoid throwing in browsers where `localStorage` is unavailable, protecting the experience for privacy-focused users.
 
 ## Testing and quality
-- **Unit tests:** `npm run test` runs the Node-based suite under `tests/`.
-- **Continuous integration:** [`ci.yml`](.github/workflows/ci.yml) validates every push, and [`static.yml`](.github/workflows/static.yml) is reserved for additional static analysis.
-- **Lighthouse audits:** [`lighthouse.yml`](.github/workflows/lighthouse.yml) executes `npx lhci autorun` against the deployed site, publishing an artifact named **`lighthouse-report`** with the latest performance, accessibility, best-practices, and SEO scores.
-- **Manual smoke testing:** Validate local changes in `npm run dev` by playing through win, draw, and reset paths to ensure focus states, narration, and persistence continue to behave as documented.
+- **Core quality commands:** Run `npm run test`, `npm run lint`, and `npm run e2e` before opening a PR so your local checks match current package scripts.
+- **Current script behavior:** `npm run test` executes real unit tests, while `npm run lint` and `npm run e2e` are placeholders that currently print status messages.
+- **Continuous integration:** [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs the same commands via `npm run test` and `npm run e2e:ci`, so CI currently enforces unit coverage and confirms the e2e hook remains callable.
+- **Lighthouse audits:** [`.github/workflows/lighthouse.yml`](.github/workflows/lighthouse.yml) executes `npx lhci autorun` against the deployed site, publishing an artifact named **`lighthouse-report`** with performance, accessibility, best-practices, and SEO scores.
+- **Manual smoke testing:** Use `npm run dev` (or `npm run serve`) and play through win, draw, reset, and settings update paths to verify focus, narration, and persistence remain stable.
 
 ## Deployment
 1. Build the distributable bundle with `npm run build` (or rely on the automated Pages workflow).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -59,7 +59,7 @@ When names change inside the settings modal, the update propagates in this seque
 
 ## Deployment notes
 
-GitHub Pages serves the contents of `site/`, so every module above must keep working with static `<script>` tags and relative asset paths. The Pages workflow copies `site/` verbatim; no bundler rewrites the module graph. When adding new JavaScript, place it under `site/js/` and update `site/index.html` (or include inline module loaders) so the Pages build automatically picks it up.
+Local development and GitHub Pages both execute the same script-loaded asset tree from `site/`: `npm run dev`/`npm run serve` launches `http-server` for that directory, and the Pages workflow copies `site/` into `dist/` via `npm run build`. Because no bundler rewrites the graph, every module above must keep working with static `<script>` tags and relative asset paths. When adding new JavaScript, place it under `site/js/` and update `site/index.html` (or include inline module loaders) so the Pages build automatically picks it up.
 
 ## Maintenance checklist
 


### PR DESCRIPTION
### Motivation
- Ensure documentation reflects the repository’s real `package.json` scripts so contributors run the same commands CI expects. 
- Standardize prerequisite wording across docs to Node.js 20+ for clarity and CI parity. 
- Make local development instructions consistent so contributors serve the same `site/` assets locally as GitHub Pages deploys.

### Description
- Updated `README.md` to standardize the prerequisite to Node.js 20+, replace the local preview wording with `npm run dev`, and replace the project scripts table so it matches `package.json` exactly (including aliases and placeholders for `lint`/`e2e`).
- Updated `CONTRIBUTING.md` to require Node.js 20+, replace the previous root-serving guidance with `npm run dev`/`npm run serve`, add a `package.json` script reference table, and align the tests/CI guidance to reference `npm run test`, `npm run lint`, and `npm run e2e` with current placeholder behavior documented.
- Clarified `docs/architecture/overview.md` deployment notes to state that local dev (`npm run dev`/`npm run serve`) and the Pages workflow (`npm run build` copying `site/` to `dist/`) use the same script-loaded `site/` assets and that no bundler rewrites the graph.
- Kept messaging about current placeholders for `npm run lint` and `npm run e2e` so contributors and CI remain aligned with the repository state.

### Testing
- Ran `npm run test` and all unit tests passed (5/5 passing). 
- Ran `npm run lint` which executed and printed the current placeholder message (`No lint script configured`). 
- Ran `npm run e2e` which executed and printed the current placeholder message (`No end-to-end tests configured`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94ca05dbc8328898fa8e397bbce1e)