### PR TITLE
test: add unit coverage for PWA install prompt UX

### DIFF
--- a/site/js/pwa/install.js
+++ b/site/js/pwa/install.js
@@ -124,6 +124,9 @@
     }
   };
 
+  const getDeferredPromptEvent = () => deferredPromptEvent;
+  const getInstallButton = () => installButton;
+
   const monitorDisplayMode = () => {
     if (!window.matchMedia) {
       return;
@@ -157,4 +160,14 @@
     }
     updateButtonState();
   });
+
+  window.__tictactoePwaInstallTestHooks = {
+    ensureInstallButton,
+    updateButtonState,
+    handleBeforeInstallPrompt,
+    handleAppInstalled,
+    getDeferredPromptEvent,
+    getInstallButton,
+    isStandalone,
+  };
 })();

--- a/tests/unit/pwa-install.test.js
+++ b/tests/unit/pwa-install.test.js
@@ -1,0 +1,159 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const path = require('node:path');
+
+const scriptPath = path.resolve(__dirname, '../../site/js/pwa/install.js');
+
+function setupDom({ hasMountPoint = true, standalone = false, hasMatchMedia = true } = {}) {
+  const mount = hasMountPoint ? '<div class="toolbar__actions" data-install-slot></div>' : '';
+  const dom = new JSDOM(`<!doctype html><html><body>${mount}</body></html>`, {
+    runScripts: 'outside-only',
+    url: 'https://example.test',
+  });
+
+  const { window } = dom;
+  window.console.warn = () => {};
+
+  Object.defineProperty(window.navigator, 'standalone', {
+    configurable: true,
+    value: standalone,
+  });
+
+  if (hasMatchMedia) {
+    window.matchMedia = (query) => ({
+      media: query,
+      matches: standalone && query === '(display-mode: standalone)',
+      addEventListener: () => {},
+      addListener: () => {},
+      removeEventListener: () => {},
+      removeListener: () => {},
+    });
+  } else {
+    delete window.matchMedia;
+  }
+
+  return dom;
+}
+
+function loadScript(dom) {
+  const { window } = dom;
+  const scriptSource = require('node:fs').readFileSync(scriptPath, 'utf8');
+  window.eval(scriptSource);
+  return window.__tictactoePwaInstallTestHooks;
+}
+
+function dispatchDomReady(window) {
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+}
+
+test('script initializes only once using __tictactoePwaInstallInitialised guard', () => {
+  const dom = setupDom();
+  const { window } = dom;
+
+  loadScript(dom);
+  const initialHooks = window.__tictactoePwaInstallTestHooks;
+  assert.equal(window.__tictactoePwaInstallInitialised, true);
+
+  loadScript(dom);
+
+  assert.equal(window.__tictactoePwaInstallTestHooks, initialHooks);
+  assert.equal(window.document.querySelectorAll('[data-role="install-button"]').length, 0);
+});
+
+test('injects install button only when mount exists and app is not standalone', () => {
+  const dom = setupDom({ hasMountPoint: true, standalone: false });
+  const hooks = loadScript(dom);
+  dispatchDomReady(dom.window);
+
+  const button = hooks.getInstallButton();
+  assert.ok(button);
+  assert.equal(button.dataset.role, 'install-button');
+
+  const noMountDom = setupDom({ hasMountPoint: false, standalone: false });
+  const noMountHooks = loadScript(noMountDom);
+  dispatchDomReady(noMountDom.window);
+  assert.equal(noMountHooks.getInstallButton(), null);
+
+  const standaloneDom = setupDom({ hasMountPoint: true, standalone: true });
+  const standaloneHooks = loadScript(standaloneDom);
+  dispatchDomReady(standaloneDom.window);
+  assert.equal(standaloneHooks.getInstallButton(), null);
+});
+
+test('button remains hidden and disabled until beforeinstallprompt event arrives', () => {
+  const dom = setupDom();
+  const hooks = loadScript(dom);
+
+  dispatchDomReady(dom.window);
+  const button = hooks.getInstallButton();
+  assert.ok(button);
+  assert.equal(button.hidden, true);
+  assert.equal(button.disabled, true);
+
+  const promptEvent = new dom.window.Event('beforeinstallprompt');
+  promptEvent.prompt = () => {};
+  promptEvent.userChoice = Promise.resolve({ outcome: 'accepted' });
+  dom.window.dispatchEvent(promptEvent);
+  dispatchDomReady(dom.window);
+
+  assert.equal(button.hidden, false);
+  assert.equal(button.disabled, false);
+});
+
+test('click calls prompt and consumes userChoice', async () => {
+  const dom = setupDom();
+  const hooks = loadScript(dom);
+
+  const calls = [];
+  let choiceConsumed = false;
+  const promptEvent = new dom.window.Event('beforeinstallprompt');
+  promptEvent.prompt = () => calls.push('prompt');
+  promptEvent.userChoice = Promise.resolve({ outcome: 'accepted' }).then((result) => {
+    choiceConsumed = true;
+    return result;
+  });
+
+  dom.window.dispatchEvent(promptEvent);
+  dispatchDomReady(dom.window);
+
+  const button = hooks.getInstallButton();
+  button.click();
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(calls, ['prompt']);
+  assert.equal(choiceConsumed, true);
+  assert.equal(hooks.getDeferredPromptEvent(), null);
+  assert.equal(button.hidden, true);
+  assert.equal(button.disabled, true);
+});
+
+test('appinstalled clears deferred prompt and hides button', () => {
+  const dom = setupDom();
+  const hooks = loadScript(dom);
+
+  const promptEvent = new dom.window.Event('beforeinstallprompt');
+  promptEvent.prompt = () => {};
+  promptEvent.userChoice = Promise.resolve({ outcome: 'accepted' });
+  dom.window.dispatchEvent(promptEvent);
+  dispatchDomReady(dom.window);
+
+  const button = hooks.getInstallButton();
+  assert.equal(button.hidden, false);
+
+  dom.window.dispatchEvent(new dom.window.Event('appinstalled'));
+
+  assert.equal(hooks.getDeferredPromptEvent(), null);
+  assert.equal(button.hidden, true);
+  assert.equal(button.disabled, true);
+});
+
+test('gracefully handles missing matchMedia and missing mount point', () => {
+  const dom = setupDom({ hasMountPoint: false, hasMatchMedia: false });
+  const hooks = loadScript(dom);
+
+  assert.doesNotThrow(() => dispatchDomReady(dom.window));
+  assert.equal(hooks.getInstallButton(), null);
+  assert.equal(hooks.isStandalone(), false);
+});


### PR DESCRIPTION
### Motivation
- Add deterministic unit coverage for the PWA install UX so install-related behavior can be validated in CI without relying on a real browser prompt.
- Make a minimal runtime-safe change to expose testable hooks so internal state and flows can be asserted in JSDOM tests.

### Description
- Add a focused JSDOM-based test suite at `tests/unit/pwa-install.test.js` that simulates `beforeinstallprompt` and `appinstalled` events and exercises the installation button lifecycle. 
- Cover initialization guard (`__tictactoePwaInstallInitialised`), mount-point injection, hidden/disabled pre-prompt state, click-to-`prompt()` and `userChoice` consumption, and `appinstalled` reset behavior. 
- Add edge-case tests for missing `matchMedia` and missing mount point to ensure graceful handling. 
- Minimal refactor to `site/js/pwa/install.js` to expose `window.__tictactoePwaInstallTestHooks` and lightweight getters (`getDeferredPromptEvent`, `getInstallButton`) while preserving the IIFE, existing guards, and production event wiring.

### Testing
- Ran the unit suite with `npm test` and all tests passed (new `tests/unit/pwa-install.test.js` plus existing unit tests succeeded). 
- The test run validates the install prompt lifecycle, click flow, and edge cases under JSDOM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94ca1b92c832892b3696e86a96d2c)