### PR TITLE
test(e2e): add scenario specs for settings, reset flows, and storage restore

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,58 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export const selectors = {
+  board: '#board',
+  cellByIndex: (index: number) => `[data-cell][data-index="${index}"]`,
+  status: '#statusMessage',
+  scoreFor: (player: 'X' | 'O' | 'draw') => `[data-role="score"][data-player="${player}"]`,
+  nameFor: (player: 'X' | 'O') => `[data-role="name"][data-player="${player}"]`,
+  settingsButton: '#settingsButton',
+  settingsModal: '#settingsModal',
+  settingsForm: '#settingsForm',
+  playerXInput: '#playerXName',
+  playerOInput: '#playerOName',
+  playerXError: '[data-error-for="playerX"]',
+  saveSettings: '#settingsForm button[type="submit"]',
+  newRoundButton: '#newRoundButton',
+  resetGameButton: '#resetGameButton',
+  resetScoresButton: '#resetScoresButton',
+};
+
+export async function gotoGame(page: Page) {
+  await page.goto('/');
+  await expect(page.locator(selectors.board)).toBeVisible();
+  await expect(page.locator(selectors.status)).toBeVisible();
+}
+
+export async function readStatus(page: Page) {
+  return ((await page.locator(selectors.status).textContent()) ?? '').trim();
+}
+
+export async function expectStatusContains(page: Page, text: RegExp | string) {
+  await expect.poll(() => readStatus(page)).toMatch(text instanceof RegExp ? text : new RegExp(text, 'i'));
+}
+
+export async function playMoves(page: Page, indexes: number[]) {
+  for (const index of indexes) {
+    await page.locator(selectors.cellByIndex(index)).click();
+  }
+}
+
+export async function expectScores(
+  page: Page,
+  expected: { X: number; O: number; draw: number }
+) {
+  await expect.poll(async () => ({
+    X: Number((await page.locator(selectors.scoreFor('X')).textContent()) ?? '0'),
+    O: Number((await page.locator(selectors.scoreFor('O')).textContent()) ?? '0'),
+    draw: Number((await page.locator(selectors.scoreFor('draw')).textContent()) ?? '0'),
+  })).toEqual(expected);
+}
+
+export async function expectDialogVisible(dialog: Locator) {
+  await expect.poll(() => dialog.evaluate((node) => (node as HTMLDialogElement).open)).toBe(true);
+}
+
+export async function expectDialogClosed(dialog: Locator) {
+  await expect.poll(() => dialog.evaluate((node) => (node as HTMLDialogElement).open)).toBe(false);
+}

--- a/tests/e2e/round-and-score-reset.spec.ts
+++ b/tests/e2e/round-and-score-reset.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { expectScores, expectStatusContains, gotoGame, playMoves, readStatus, selectors } from './helpers';
+
+test.describe('Round and score reset flows', () => {
+  test('honors confirmation behavior for new round, reset game, and reset scores', async ({ page }) => {
+    await gotoGame(page);
+
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue?: boolean[] }).__confirmQueue = [];
+      window.confirm = () => {
+        const queue = (window as typeof window & { __confirmQueue?: boolean[] }).__confirmQueue ?? [];
+        return queue.shift() ?? true;
+      };
+    });
+
+    await playMoves(page, [0, 3, 1, 4, 2]);
+    await expectStatusContains(page, /wins/i);
+    await expectScores(page, { X: 1, O: 0, draw: 0 });
+
+    await playMoves(page, [8]);
+    await expect(page.locator(selectors.cellByIndex(8))).toHaveAttribute('data-value', '');
+
+    await playMoves(page, [0]);
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(false);
+    });
+    const boardBeforeCancel = await page.locator(selectors.cellByIndex(0)).getAttribute('data-value');
+    await page.locator(selectors.newRoundButton).click();
+    await expect(page.locator(selectors.cellByIndex(0))).toHaveAttribute('data-value', boardBeforeCancel ?? 'X');
+
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(true);
+    });
+    await page.locator(selectors.newRoundButton).click();
+    await expect(page.locator(selectors.cellByIndex(0))).not.toHaveAttribute('data-value', /X|O/);
+    await expectScores(page, { X: 1, O: 0, draw: 0 });
+    await expectStatusContains(page, /to move/i);
+
+    await playMoves(page, [0]);
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(false);
+    });
+    await page.locator(selectors.resetGameButton).click();
+    await expect(page.locator(selectors.cellByIndex(0))).toHaveAttribute('data-value', 'X');
+    await expectScores(page, { X: 1, O: 0, draw: 0 });
+
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(true);
+    });
+    await page.locator(selectors.resetGameButton).click();
+    await expectScores(page, { X: 0, O: 0, draw: 0 });
+    await expectStatusContains(page, /player x.*to move/i);
+
+    await playMoves(page, [0, 1, 3, 4, 6]);
+    await expectScores(page, { X: 1, O: 0, draw: 0 });
+
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(false);
+    });
+    await page.locator(selectors.resetScoresButton).click();
+    await expectScores(page, { X: 1, O: 0, draw: 0 });
+
+    const statusBeforeScoreReset = await readStatus(page);
+    await page.evaluate(() => {
+      (window as typeof window & { __confirmQueue: boolean[] }).__confirmQueue.push(true);
+    });
+    await page.locator(selectors.resetScoresButton).click();
+    await expectScores(page, { X: 0, O: 0, draw: 0 });
+    await expect.poll(() => readStatus(page)).toBe(statusBeforeScoreReset);
+  });
+});

--- a/tests/e2e/settings-persistence.spec.ts
+++ b/tests/e2e/settings-persistence.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { expectDialogClosed, expectDialogVisible, gotoGame, selectors } from './helpers';
+
+test.describe('Settings persistence and validation', () => {
+  test('blocks save for invalid names and persists valid names/theme/accent after reload', async ({
+    page,
+  }) => {
+    await gotoGame(page);
+
+    const dialog = page.locator(selectors.settingsModal);
+    await page.locator(selectors.settingsButton).click();
+    await expectDialogVisible(dialog);
+
+    await page.locator(selectors.playerXInput).fill('Invalid@Name');
+    await page.locator(selectors.playerOInput).fill('Valid Name');
+    await page.locator(selectors.saveSettings).click();
+
+    const xError = page.locator(selectors.playerXError);
+    await expect(xError).toBeVisible();
+    await expect(xError).toContainText(/letters|numbers|hyphens|periods/i);
+    await expectDialogVisible(dialog);
+
+    await expect(page.locator(selectors.nameFor('X'))).toHaveText('Player X');
+
+    await page.locator(selectors.playerXInput).fill('Alex');
+    await page.locator('input[name="theme"][value="dark"]').check();
+    await page.locator('input[name="accent"][value="rose"]').check();
+    await page.locator(selectors.saveSettings).click();
+    await expectDialogClosed(dialog);
+
+    await expect(page.locator(selectors.nameFor('X'))).toHaveText('Alex');
+    await expect(page.locator(selectors.nameFor('O'))).toHaveText('Valid Name');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveAttribute('data-accent', 'rose');
+
+    await page.reload();
+    await gotoGame(page);
+
+    await expect(page.locator(selectors.nameFor('X'))).toHaveText('Alex');
+    await expect(page.locator(selectors.nameFor('O'))).toHaveText('Valid Name');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveAttribute('data-accent', 'rose');
+  });
+});

--- a/tests/e2e/storage-restore.spec.ts
+++ b/tests/e2e/storage-restore.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { expectScores, expectStatusContains, gotoGame, selectors } from './helpers';
+
+test.describe('Storage restore', () => {
+  test('restores saved scores, board position, names, and appearance from localStorage', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('tictactoe:scores', JSON.stringify({ X: 2, O: 1, draw: 3 }));
+      localStorage.setItem(
+        'tictactoe:game-state',
+        JSON.stringify({
+          board: ['X', 'O', null, null, 'X', null, null, null, null],
+          currentPlayer: 'O',
+          isRoundOver: false,
+          winningLine: null,
+        })
+      );
+      localStorage.setItem('tictactoe:player-names', JSON.stringify({ X: 'Riley', O: 'Quinn' }));
+      localStorage.setItem(
+        'tictactoe:appearance',
+        JSON.stringify({ theme: 'dark', accent: 'emerald' })
+      );
+    });
+
+    await gotoGame(page);
+
+    await expectScores(page, { X: 2, O: 1, draw: 3 });
+    await expect(page.locator(selectors.nameFor('X'))).toHaveText('Riley');
+    await expect(page.locator(selectors.nameFor('O'))).toHaveText('Quinn');
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('html')).toHaveAttribute('data-accent', 'emerald');
+
+    await expect(page.locator(selectors.cellByIndex(0))).toHaveAttribute('data-value', 'X');
+    await expect(page.locator(selectors.cellByIndex(1))).toHaveAttribute('data-value', 'O');
+    await expect(page.locator(selectors.cellByIndex(4))).toHaveAttribute('data-value', 'X');
+    await expectStatusContains(page, /quinn.*\(o\).*to move/i);
+
+    await page.locator(selectors.cellByIndex(2)).click();
+    await expect(page.locator(selectors.cellByIndex(2))).toHaveAttribute('data-value', 'O');
+    await expectStatusContains(page, /riley.*\(x\).*to move/i);
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve end-to-end coverage for user-visible and accessibility behaviour around settings, rounds, and persistence to prevent regressions. 
- Reduce flakiness by centralising stable selectors and deterministic wait/read helpers so CI can run scenario-based specs reliably.

### Description

- Add a shared Playwright helper module `tests/e2e/helpers.ts` that exposes stable selectors and utilities such as `gotoGame`, `playMoves`, `readStatus`, `expectScores`, and dialog polling. 
- Add `tests/e2e/settings-persistence.spec.ts` which asserts invalid player names surface inline errors and block saving, and that valid names plus `theme`/`accent` persist after reload. 
- Add `tests/e2e/round-and-score-reset.spec.ts` which validates confirmation flows for `New round`, `Reset game`, and `Reset scores`, and verifies score/status consistency across cancel/confirm paths by controlling `window.confirm`. 
- Add `tests/e2e/storage-restore.spec.ts` which seeds `localStorage` via `page.addInitScript` and verifies restoration of scores, board state, current player, player names, and appearance.

### Testing

- Attempted to run the new suite with `npx playwright test tests/e2e --workers=1 --reporter=line`, which executed the four new specs but failed to launch browsers because Playwright browsers were not installed (`Executable doesn't exist ... headless_shell`).
- No other automated test failures were introduced by these files; to execute the e2e suite locally or in CI install browsers with `npx playwright install` and then run `npx playwright test tests/e2e --workers=1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94ca426f88328984a5a0890761fbe)