### PR TITLE
feat(ci): verify root index.html stays synced with site/index.html

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+      - name: Verify root/site HTML sync
+        run: npm run verify:html-sync
+
       - name: Run unit tests
         run: npm test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ This project is built with vanilla HTML, CSS, and JavaScript. Please adhere to t
 ## Local development workflow
 
 ### Prerequisites
-- [Node.js](https://nodejs.org/) 18 or newer (for linting/formatting commands).
+- [Node.js](https://nodejs.org/) 20 or newer (aligned with CI and required scripts).
 - A modern web browser for manual testing.
 
 ### Running the site locally
@@ -57,6 +57,10 @@ Run the following commands from the project root before committing:
 
 ```bash
 npx prettier --check "**/*.{html,css,js}"
+```
+
+```bash
+npm run verify:html-sync
 ```
 
 If the check fails, format the files automatically:
@@ -85,8 +89,9 @@ If you add new automated checks, update this section with instructions and ensur
 
 ## Continuous integration & deployment
 
-- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs `npm test`, and expects an `npm run e2e:ci` command to exercise the Playwright specs. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
+- Pull requests are validated by [`.github/workflows/ci.yml`](.github/workflows/ci.yml). That workflow installs dependencies, runs linting, verifies root/site HTML sync (`npm run verify:html-sync`), runs `npm test`, and executes `npm run e2e:ci` for Playwright coverage. Keep your local workflow aligned with those steps so what passes locally mirrors CI.
 - Merges to `main` automatically trigger the GitHub Pages deployment pipeline. To keep deployments healthy, confirm that `index.html` and any assets you add load correctly when served from the repository root, and avoid introducing references to private or server-side resources.
+- If you touch either `site/index.html` or root `index.html`, run `npm run verify:html-sync` before committing. If it fails, sync root markup from `site/index.html` and preserve only `<base href="./site/" />` in the root file.
 - If a deployment fails, investigate the CI logs and open a follow-up PR with a fix or revert.
 
 ## Getting help

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The live app is structured to make every round easy to follow:
 | `npm run dev` | Serves the contents of `site/` locally using `http-server`. |
 | `npm run build` | Copies `site/` into `dist/`, mirroring the GitHub Pages packaging step. |
 | `npm run test` | Executes the Node-based unit tests located in `tests/`. |
+| `npm run verify:html-sync` | Verifies root `index.html` mirrors `site/index.html` (with only `<base href="./site/">` added) and checks required runtime anchors/assets. |
 | `npm run e2e` | Placeholder stub for end-to-end tests; currently prints a status message. |
 | `npm run e2e:ci` | CI alias that proxies to `npm run e2e` so the workflow succeeds until real tests ship. |
 | `npm run lint` | Reserved for future lint rules (no-op today). |
@@ -103,6 +104,7 @@ This modular structure keeps the board responsive, enables drop-in enhancements 
 
 ## Testing and quality
 - **Unit tests:** `npm run test` runs the Node-based suite under `tests/`.
+- **HTML sync guard:** `npm run verify:html-sync` ensures the root `index.html` stays in lockstep with `site/index.html` for GitHub Pages root serving. If it fails, copy changes from `site/index.html` into `index.html` and keep only the root `<base href="./site/" />` difference.
 - **Continuous integration:** [`ci.yml`](.github/workflows/ci.yml) validates every push, and [`static.yml`](.github/workflows/static.yml) is reserved for additional static analysis.
 - **Lighthouse audits:** [`lighthouse.yml`](.github/workflows/lighthouse.yml) executes `npx lhci autorun` against the deployed site, publishing an artifact named **`lighthouse-report`** with the latest performance, accessibility, best-practices, and SEO scores.
 - **Manual smoke testing:** Validate local changes in `npm run dev` by playing through win, draw, and reset paths to ensure focus states, narration, and persistence continue to behave as documented.

--- a/index.html
+++ b/index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
-<!-- This file mirrors site/index.html so the root URL renders the game directly. -->
 <html lang="en">
   <head>
     <base href="./site/" />
-
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tic Tac Toe</title>
@@ -47,7 +45,7 @@
         class="scoreboard"
         id="scoreboard"
         role="region"
-        aria-label="Player scoreboard"
+        aria-label="Scoreboard with wins and draws"
       >
         <article class="scoreboard__player scoreboard__player--x" data-player="X">
           <span class="scoreboard__mark" aria-hidden="true">X</span>
@@ -74,6 +72,21 @@
               data-role="score"
               data-player="O"
               aria-labelledby="score-label-o"
+              aria-live="polite"
+              >0</span
+            >
+          </span>
+        </article>
+        <article class="scoreboard__player scoreboard__player--draw" data-player="draw">
+          <span class="scoreboard__mark" aria-hidden="true">=</span>
+          <span class="scoreboard__name">Draws</span>
+          <span class="scoreboard__score" data-player="draw">
+            <span id="score-label-draw" class="visually-hidden">Total drawn rounds</span>
+            <span
+              class="scoreboard__score-value"
+              data-role="score"
+              data-player="draw"
+              aria-labelledby="score-label-draw"
               aria-live="polite"
               >0</span
             >

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "echo \"No lint script configured\"",
     "test": "node --test tests/unit",
     "e2e": "echo \"No end-to-end tests configured\"",
-    "e2e:ci": "npm run e2e"
+    "e2e:ci": "npm run e2e",
+    "verify:html-sync": "node scripts/verify-index-sync.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.1",

--- a/scripts/verify-index-sync.mjs
+++ b/scripts/verify-index-sync.mjs
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const rootIndexPath = path.join(repoRoot, 'index.html');
+const siteIndexPath = path.join(repoRoot, 'site', 'index.html');
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function getAttrValues(html, tagName, attrName) {
+  const tagPattern = new RegExp(`<${tagName}\\b[^>]*>`, 'gi');
+  const attrPattern = new RegExp(`${attrName}\\s*=\\s*['\"]([^'\"]+)['\"]`, 'i');
+  const values = [];
+  const tags = html.match(tagPattern) ?? [];
+  for (const tag of tags) {
+    const match = tag.match(attrPattern);
+    if (match) values.push(match[1]);
+  }
+  return values;
+}
+
+function stripBaseTag(html) {
+  return html.replace(/<base\b[^>]*>\s*/i, '');
+}
+
+function normalizeForComparison(html) {
+  return html.replace(/\r\n/g, '\n').replace(/>\s+</g, '><').trim();
+}
+
+if (!existsSync(rootIndexPath) || !existsSync(siteIndexPath)) {
+  fail('Both index.html and site/index.html must exist.');
+  process.exit(process.exitCode ?? 1);
+}
+
+const rootHtml = readFileSync(rootIndexPath, 'utf8');
+const siteHtml = readFileSync(siteIndexPath, 'utf8');
+
+const baseValues = getAttrValues(rootHtml, 'base', 'href');
+if (baseValues.length !== 1 || baseValues[0] !== './site/') {
+  fail('Root index.html must contain exactly one <base href="./site/"> tag.');
+}
+
+const rootScripts = getAttrValues(rootHtml, 'script', 'src');
+const siteScripts = getAttrValues(siteHtml, 'script', 'src');
+if (JSON.stringify(rootScripts) !== JSON.stringify(siteScripts)) {
+  fail('Script src references differ between root index.html and site/index.html.');
+}
+
+const rootStyles = getAttrValues(rootHtml, 'link', 'href');
+const siteStyles = getAttrValues(siteHtml, 'link', 'href');
+if (JSON.stringify(rootStyles) !== JSON.stringify(siteStyles)) {
+  fail('Link href references differ between root index.html and site/index.html.');
+}
+
+const requiredAnchors = [
+  'id="board"',
+  'id="statusMessage"',
+  'id="newRoundButton"',
+  'id="resetGameButton"',
+  'id="resetScoresButton"',
+  'id="settingsButton"',
+  'id="settingsModal"',
+  'id="settingsForm"'
+];
+
+for (const anchor of requiredAnchors) {
+  if (!rootHtml.includes(anchor)) {
+    fail(`Missing required runtime anchor in root index.html: ${anchor}`);
+  }
+
+  if (!siteHtml.includes(anchor)) {
+    fail(`Missing required runtime anchor in site/index.html: ${anchor}`);
+  }
+}
+
+const normalizedRoot = normalizeForComparison(stripBaseTag(rootHtml));
+const normalizedSite = normalizeForComparison(siteHtml);
+if (normalizedRoot !== normalizedSite) {
+  fail('Root index.html must mirror site/index.html except for the <base> tag.');
+}
+
+if (process.exitCode && process.exitCode !== 0) {
+  console.error('\nRoot/site index sync verification failed.');
+  process.exit(process.exitCode);
+}
+
+console.log('✅ Root index.html is synchronized with site/index.html integration expectations.');


### PR DESCRIPTION
### Motivation
- Prevent regressions where the root `index.html` diverges from `site/index.html` and breaks GitHub Pages root-serving expectations. 
- Ensure asset and script references resolve correctly when the site is served from the repository root via the `<base>` tag. 
- Make runtime DOM anchors explicit so client scripts can rely on stable IDs and avoid subtle runtime failures. 
- Provide contributors an automated, easy-to-run check and remediation guidance to keep the two index files in sync.

### Description
- Add `scripts/verify-index-sync.mjs`, a Node script that enforces a single ` <base href="./site/">` in root `index.html`, verifies matching `script` and `link` references, checks required runtime anchors, and compares normalized markup between `index.html` and `site/index.html` (allowing only the base tag difference). 
- Add an npm script `verify:html-sync` that runs the new verification script. 
- Wire the new check into CI by running `npm run verify:html-sync` in `.github/workflows/ci.yml` before unit tests. 
- Update `index.html` to mirror `site/index.html` (keeping the ` <base href="./site/">` difference) and document the new rule and remediation steps in `README.md` and `CONTRIBUTING.md` with a contributor reminder to run the check when touching either index file.

### Testing
- Ran `npm run verify:html-sync` locally and it completed successfully with the message that root and site indexes are synchronized. 
- Ran `npm test` and the unit suite passed (`5` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94ca50290832881ba0d26ef3cf6b3)